### PR TITLE
Refactor flex-container to make it easier to input parameters

### DIFF
--- a/core/utilities/mixins/_flex-container.scss
+++ b/core/utilities/mixins/_flex-container.scss
@@ -2,7 +2,8 @@
 
 // Default set of parameters.
 $flex-container-defaults: (
-  'selector': '*',
+  'parent': '&',
+  'children': '> *',
   'flex': flex,
   'flex-direction': row,
   'flex-wrap': wrap,
@@ -40,7 +41,8 @@ $flex-container-defaults: (
 @mixin flex-container($settings-map: $flex-container-defaults) {
 
   // Pull out the parts for easy use.
-  $selector: map-get('selector', $settings-map);
+  $parent: map-get('parent', $settings-map);
+  $children: map-get('children', $settings-map);
   $flex: map-get('flex', $settings-map);
   $flex-direction: map-get('flex-direction', $settings-map);
   $flex-wrap: map-get('flex-wrap', $settings-map);
@@ -51,24 +53,24 @@ $flex-container-defaults: (
   $flex-shrink: map-get('flex-shrink', $settings-map);
   $flex-basis: map-get('flex-basis', $settings-map);
 
-  // Inherited properties from mixin.
-  display:          $flex;
-  flex-flow:        $flex-direction $flex-wrap; // default: row wrap;
-  justify-content:  $justify-content; // default: flex-start;
-  align-items:      $align-items; // default: flex-start;
-  align-content:    $align-content; // default: flex-start;
+  #{$parent} {
+    // Inherited properties from mixin.
+    display:          $flex;
+    flex-flow:        $flex-direction $flex-wrap; // default: row wrap;
+    justify-content:  $justify-content; // default: flex-start;
+    align-items:      $align-items; // default: flex-start;
+    align-content:    $align-content; // default: flex-start;
 
-  // Opinionated properties
-  box-sizing: border-box;
+    // Opinionated properties
+    box-sizing: border-box;
 
-  // Applies the direct children
-  > #{$selector} {
-    // Inherited properties from mixin
-    flex: $flex-grow $flex-shrink $flex-basis; // default: flex: 0 0 auto;
+    // Applies the direct children
+    #{$children} {
+      // Inherited properties from mixin
+      flex: $flex-grow $flex-shrink $flex-basis; // default: flex: 0 0 auto;
 
-    // align-self: $_align-self; // default: align-self: flex-start; -- this should be set at the element level, and not here
-
-    //Opinionated properties
-    box-sizing: inherit;
+      //Opinionated properties
+      box-sizing: inherit;
+    }
   }
 }

--- a/core/utilities/mixins/_flex-container.scss
+++ b/core/utilities/mixins/_flex-container.scss
@@ -1,42 +1,56 @@
 @charset "UTF-8";
 
+// Default set of parameters.
+$flex-container-defaults: (
+  'selector': '*',
+  'flex': flex,
+  'flex-direction': row,
+  'flex-wrap': wrap,
+  'justify-content': center,
+  'align-items': flex-start,
+  'align-content': center,
+  'flex-grow': 0,
+  'flex-shrink': 0,
+  'flex-basis': auto
+) !default;
+
 /// Creates a flexbox container with children
 /// See: https://css-tricks.com/snippets/css/a-guide-to-flexbox for flexbox property explanations.
 ///
-/// $_selector: *,
-/// $_flex: flex, // flex | inline-flex
+/// selector: *,
+/// flex: flex, // flex | inline-flex
 ///
 /// // Parent properties
-/// $_flex-direction: row, // row | row-reverse | column | column-reverse
-/// $_flex-wrap: wrap, // nowrap | wrap | wrap-reverse
+/// flex-direction: row, // row | row-reverse | column | column-reverse
+/// flex-wrap: wrap, // nowrap | wrap | wrap-reverse
 ///
 /// // Change $_justify-content from 'center' to 'flex-start' to left align wrapped orphans
-/// $_justify-content: center, // flex-start | flex-end | center | space-between | space-around
+/// justify-content: center, // flex-start | flex-end | center | space-between | space-around
 ///
 /// // Change $_align-items from `flex-start` to `stretch` for equal heights
-/// $_align-items: flex-start, //  flex-start | flex-end | center | baseline | stretch
+/// align-items: flex-start, //  flex-start | flex-end | center | baseline | stretch
 ///
-/// $_align-content: center, // flex-start | flex-end | center | space-between | space-around | stretch
+/// align-content: center, // flex-start | flex-end | center | space-between | space-around | stretch
 /// // Children properties
-/// $_flex-grow: 0,
-/// $_flex-shrink: 0,
-/// $_flex-basis: auto
+/// flex-grow: 0,
+/// flex-shrink: 0,
+/// flex-basis: auto
 /// //  $_order: <integer>  // Note that this should be set at the element level
 /// // $_align-self: flex-start // Note that this should be set at the element level
-@mixin flex-container
-(
-  $selector: '*',
-  $flex: flex,
-  $flex-direction: row,
-  $flex-wrap: wrap,
-  $justify-content: center,
-  $align-items: flex-start,
-  $align-content: center,
-  $flex-grow: 0,
-  $flex-shrink: 0,
-  $flex-basis: auto
-)
-{
+@mixin flex-container($settings-map: $flex-container-defaults) {
+
+  // Pull out the parts for easy use.
+  $selector: map-get('selector', $settings-map);
+  $flex: map-get('flex', $settings-map);
+  $flex-direction: map-get('flex-direction', $settings-map);
+  $flex-wrap: map-get('flex-wrap', $settings-map);
+  $justify-content: map-get('justify-content', $settings-map);
+  $align-items: map-get('align-items', $settings-map);
+  $align-content: map-get('align-content', $settings-map);
+  $flex-grow: map-get('flex-grow', $settings-map);
+  $flex-shrink: map-get('flex-shrink', $settings-map);
+  $flex-basis: map-get('flex-basis', $settings-map);
+
   // Inherited properties from mixin.
   display:          $flex;
   flex-flow:        $flex-direction $flex-wrap; // default: row wrap;


### PR DESCRIPTION
This refactors the flex-container mixin to use a map as the parameter instead of an overloaded function parameter set. 

The reason for this is that if I wanted all of the defaults except the flex grow option I would have to input all of the parameters (7) up to that param and that is annoying and possibly a breaking point for future defaults.