### PR TITLE
Smart Quotes

### DIFF
--- a/core/base/_typography.scss
+++ b/core/base/_typography.scss
@@ -68,14 +68,30 @@ dfn, cite, em, i {
   font-style: italic;
 }
 
-/// @require {variable} $base-spacing
-blockquote, q {
+/// @require {function} modular-scale
+// see https://css-tricks.com/almanac/properties/q/quotes/
+blockquote {
   margin: 0 modular-scale(2);
-  quotes: "" "";
+  quotes: "\201c" "\201d" "\2018" "\2019";
 
-  &:before,
-  &:after {
-    content: "";
+  &::before {
+    content: open-quote;
+  }
+  &::after {
+    content: close-quote;
+  }
+}
+
+// see https://css-tricks.com/almanac/properties/q/quotes/
+q {
+  margin: 0;
+  quotes: "\201c" "\201d" "\2018" "\2019";
+
+  &::before {
+    content: open-quote;
+  }
+  &::after {
+    content: close-quote;
   }
 }
 


### PR DESCRIPTION
# READY
There is full browser support for `<blockquote>` and `<q>` elements. Apparently nobody has really bothered to implement them, but they are there, in the spec, being awesome.

This implements double and single typographical quotes around `<blockquote>` and `<q>` elements, with correct double first, then nested single inside double properties. This means when quoting someone, s, instead of `so and so said "this is crazy!"`, you can say `so and so said <q>this is crazy!</q>`