### PR TITLE
Prevent font loading leakage.

### DIFF
--- a/core/base/_typography.scss
+++ b/core/base/_typography.scss
@@ -9,6 +9,8 @@
 /// @see $group__element
 ////
 
+/// Load the font-face declarations.
+@include load-fonts($base-fonts);
 
 // ---------------------------------------------------------------------------------------------------------------------
 /// - Set the root body font size

--- a/core/utilities/variables/_typography.scss
+++ b/core/utilities/variables/_typography.scss
@@ -19,9 +19,6 @@ $base-font-families: (
   serif:      "'Noto Serif', #{$font-stack-georgia}"
 ) !default;
 
-/// Load the font-face declarations.
-@include load-fonts($base-fonts);
-
 // Semantic definitions
 // These map the generic `$font-family-serif` stacks to more functional, semantic
 // font stacks. `$base-font-family`, `$heading-font-family`, `$code-font-family`


### PR DESCRIPTION
When I include just the utilities roll up I was getting the base fonts loaded each time.

The base typography file seems like a better home for this function.