### PR TITLE
don't require kss to be installed globally

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function(grunt) {
     },
     run: {
       styleguide: {
-        "cmd": "kss",
+        "cmd": "./node_modules/.bin/kss",
         "args": ['--config=kss-config.json']
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decanter",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4599,7 +4599,7 @@
     "grunt-sass-lint": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/grunt-sass-lint/-/grunt-sass-lint-0.2.4.tgz",
-      "integrity": "sha1-Bvd2Na2KUEiWjqM8VYS0ChgoHjU=",
+      "integrity": "sha512-jV88yXoxFFvr4R3WVBl0uz4YBzNxXTrCJ7ZBKrYby/SjRCw2sieKPkt5tpWDcQZIj9XrKsOpKuHQn08MaECVwg==",
       "dev": true,
       "requires": {
         "sass-lint": "1.12.1"


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Use the local kss npm package to generate the style guide

## Urgency
- Whenever

## Steps to Test

1. `npm uninstall -g kss`
2. `grunt styleguide`

## Affected Projects or Products
- N/A

## Associated Issues and/or People
- #93

## See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
