### PR TITLE
ARCH-184 added images element and all necessary files to apply image defaults

### DIFF
--- a/css/decanter-grid.css
+++ b/css/decanter-grid.css
@@ -11,8 +11,7 @@ body {
   overflow-x: hidden; }
 
 .lt-ie9 * {
-  -webkit-filter: none !important;
-          filter: none !important; }
+  filter: none !important; }
 
 [hidden] {
   display: none !important; }
@@ -267,4 +266,5 @@ body {
 
 .decanter-offset-eleven-twelfths {
   margin-left: 93.8278476881%; }
+
 /*# sourceMappingURL=decanter-grid.css.map */

--- a/css/decanter-no-markup.css
+++ b/css/decanter-no-markup.css
@@ -1,2 +1,2 @@
 
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiIsImZpbGUiOiJkZWNhbnRlci1uby1tYXJrdXAuY3NzIn0= */
+/*# sourceMappingURL=decanter-no-markup.css.map */

--- a/css/decanter.css
+++ b/css/decanter.css
@@ -74,8 +74,7 @@ abbr[title] {
   /* 1 */
   text-decoration: underline;
   /* 2 */
-  -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
+  text-decoration: underline dotted;
   /* 2 */ }
 
 /**
@@ -652,8 +651,7 @@ body {
   overflow-x: hidden; }
 
 .lt-ie9 * {
-  -webkit-filter: none !important;
-          filter: none !important; }
+  filter: none !important; }
 
 [hidden] {
   display: none !important; }
@@ -677,12 +675,17 @@ body {
     width: 100%;
     height: 100%; }
 
+img {
+  display: block;
+  height: auto;
+  max-width: 100%;
+  margin: 0;
+  padding: 0; }
+
 input,
 textarea,
 select {
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
+  appearance: none;
   border: 0.1rem solid #b6b1a9;
   border-radius: 0;
   box-sizing: border-box;
@@ -1202,9 +1205,7 @@ button,
   margin-right: 0.5em;
   margin-bottom: 0.5em;
   padding: 1rem 2rem;
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
+  appearance: none;
   background-color: #b1040e;
   border: 0;
   color: #ffffff;
@@ -1256,9 +1257,7 @@ a.decanter-button--secondary {
   margin-right: 0.5em;
   margin-bottom: 0.5em;
   padding: 1rem 2rem;
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
+  appearance: none;
   background-color: #ffffff;
   border: 0;
   box-shadow: inset 0 0 0 2px #b1040e;
@@ -1298,9 +1297,7 @@ a.decanter-button--big {
   margin-right: 0.5em;
   margin-bottom: 0.5em;
   padding: 1.5rem 3rem;
-  -webkit-appearance: none;
-     -moz-appearance: none;
-          appearance: none;
+  appearance: none;
   background-color: #b1040e;
   border: 0;
   color: #ffffff;
@@ -1478,8 +1475,7 @@ a.decanter-button--unstyled {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  -webkit-transform: translateX(26rem);
-          transform: translateX(26rem);
+  transform: translateX(26rem);
   width: 26rem;
   z-index: 9000; }
   @media screen and (min-width: 951px) {
@@ -1492,12 +1488,10 @@ a.decanter-button--unstyled {
       float: right;
       overflow-y: visible;
       position: relative;
-      -webkit-transform: translateX(0);
-              transform: translateX(0);
+      transform: translateX(0);
       width: auto; } }
   .decanter-nav.is-visible {
-    -webkit-transform: translateX(0);
-            transform: translateX(0);
+    transform: translateX(0);
     transition: all 0.3s ease-in-out; }
   .decanter-nav nav {
     margin-top: 6rem;
@@ -1989,4 +1983,5 @@ a.decanter-button--unstyled {
   border-bottom: 1px solid #b6b1a9;
   border-left: 1px solid #b6b1a9;
   border-right: 1px solid #b6b1a9; }
+
 /*# sourceMappingURL=decanter.css.map */

--- a/scss/elements/_images.scss
+++ b/scss/elements/_images.scss
@@ -5,7 +5,7 @@
 //
 // Default styles for images.
 //
-// Markup: ../../templates/elements/images/images.twig
+// Markup: <img src="../../../img/hero-banner.png" alt="Stanford University Columns">
 //
 // Style guide: Elements.Images
 //

--- a/scss/elements/_images.scss
+++ b/scss/elements/_images.scss
@@ -1,0 +1,14 @@
+@charset "UTF-8";
+
+//
+// Images
+//
+// Default styles for images.
+//
+// Markup: ../../templates/elements/images/images.twig
+//
+// Style guide: Elements.Images
+//
+img {
+  @include image-defaults;
+}

--- a/scss/elements/index.scss
+++ b/scss/elements/index.scss
@@ -10,6 +10,7 @@
 @import
   'helpers/index',
   'embed',
+  'images',
   'inputs',
   'links',
   'list',

--- a/scss/utilities/mixins/images/_image-defaults.scss
+++ b/scss/utilities/mixins/images/_image-defaults.scss
@@ -1,0 +1,17 @@
+@charset "UTF-8";
+
+//
+// @image-defaults
+//
+// Default image styling to help with layout and responsiveness.
+//
+// Style guide: Mixins.Images.image-defaults
+//
+@mixin image-defaults {
+  display: block;
+  height: auto;
+  max-width: 100%;
+
+  @include margin(0);
+  @include padding(0);
+}

--- a/scss/utilities/mixins/images/index.scss
+++ b/scss/utilities/mixins/images/index.scss
@@ -1,0 +1,12 @@
+@charset "UTF-8";
+
+//
+// Images
+//
+// Mixins for Images
+//
+// Style guide: Mixins.Images
+//
+
+@import
+  'image-defaults';

--- a/scss/utilities/mixins/index.scss
+++ b/scss/utilities/mixins/index.scss
@@ -13,6 +13,7 @@
   'grid/index',
   'icon-block/index',
   'icon-grid/index',
+  'images/index',
   'links/index',
   'lists/index',
   'menus/index',

--- a/styleguide/item-elements-images.html
+++ b/styleguide/item-elements-images.html
@@ -136,17 +136,15 @@
           
           <div class="kss-modifier__example">
             <img src="../../../img/hero-banner.png" alt="Stanford University Columns">
-
             <div class="kss-modifier__example-footer"></div>
           </div>
 
                   </div>
                   <details class="kss-markup kss-style">
             <summary>
-                              Markup: <code>../templates/elements/images/images.twig</code>
+                              Markup
                           </summary>
-            <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;img src=&quot;../../../img/hero-banner.png&quot; alt=&quot;Stanford University Columns&quot;&gt;
-</code></pre>
+            <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;img src=&quot;../../../img/hero-banner.png&quot; alt=&quot;Stanford University Columns&quot;&gt;</code></pre>
           </details>
               
               <div class="kss-source kss-style">

--- a/styleguide/item-elements-images.html
+++ b/styleguide/item-elements-images.html
@@ -77,31 +77,80 @@
 <article role="main" class="kss-main">
 
   
-          <div id="kssref-mixins-menus-outter-megamenu" class="kss-section kss-section--depth-3 is-fullscreen">
+          <div id="kssref-elements-images" class="kss-section kss-section--depth-2 is-fullscreen">
       <div class="kss-style">
-                <h3 class="kss-title kss-title--level-3">
-          <a class="kss-title__permalink" href="#kssref-mixins-menus-outter-megamenu">
+                <h2 class="kss-title kss-title--level-2">
+          <a class="kss-title__permalink" href="#kssref-elements-images">
             <span class="kss-title__ref">
-              8.12.3
+              6.3
               <span class="kss-title__permalink-hash">
-                Mixins.Menus.outter-megamenu
+                Elements.Images
               </span>
             </span>
-            @outer-megamenu
+            Images
           </a>
-        </h3>
+        </h2>
 
+                  <p class="kss-toolbar">
+                        <a href="#kssref-elements-images" data-kss-guides="true">
+              <span class="kss-toolbar__tooltip">Toggle example guides</span>
+              <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100%" height="100%" viewBox="0 0 64 64">
+                <rect class="kss-toolbar__icon-fill" x="5" y="35" width="5" height="9"/>
+                <rect class="kss-toolbar__icon-fill" x="54" y="21" width="5" height="9"/>
+                <rect class="kss-toolbar__icon-fill" x="54" y="35" width="5" height="9"/>
+                <rect class="kss-toolbar__icon-fill" x="5" y="21" width="5" height="9"/>
+                <rect class="kss-toolbar__icon-fill" x="5" y="0" width="5" height="15"/>
+                <rect class="kss-toolbar__icon-fill" x="35" y="5" width="9" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="20" y="5" width="9" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="0" y="5" width="15" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="54" y="0" width="5" height="15"/>
+                <rect class="kss-toolbar__icon-fill" x="49" y="5" width="15" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="54" y="49" width="5" height="15"/>
+                <rect class="kss-toolbar__icon-fill" x="49" y="54" width="15" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="5" y="49" width="5" height="15"/>
+                <rect class="kss-toolbar__icon-fill" x="0" y="54" width="15" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="35" y="54" width="9" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="20" y="54" width="9" height="5"/>
+              </svg>
+            </a>
+            <a href="#kssref-elements-images" data-kss-markup="true">
+              <span class="kss-toolbar__tooltip">Toggle HTML markup</span>
+              <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100%" height="100%" viewBox="0 0 64 64">
+                <path class="kss-toolbar__icon-fill" d="M37.555,46.239l6.103,6.103l20.342,-20.342l-20.342,-20.342l-6.103,6.103l14.24,14.239l-14.24,14.239Z"/>
+                <path class="kss-toolbar__icon-fill" d="M26.445,17.761l-6.103,-6.103l-20.342,20.342l20.342,20.342l6.103,-6.103l-14.24,-14.239l14.24,-14.239Z"/>
+              </svg>
+            </a>
+          </p>
         
                   <div class="kss-description">
-            <p>@TODO Needs to be documented.</p>
+            <p>Default styles for images.</p>
 
           </div>
         
               </div>
 
-      
+              <div class="kss-modifier__wrapper">
+          <div class="kss-modifier__heading kss-style">
+            Example          </div>
+
+          
+          <div class="kss-modifier__example">
+            <img src="../../../img/hero-banner.png" alt="Stanford University Columns">
+
+            <div class="kss-modifier__example-footer"></div>
+          </div>
+
+                  </div>
+                  <details class="kss-markup kss-style">
+            <summary>
+                              Markup: <code>../templates/elements/images/images.twig</code>
+                          </summary>
+            <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;img src=&quot;../../../img/hero-banner.png&quot; alt=&quot;Stanford University Columns&quot;&gt;
+</code></pre>
+          </details>
+              
               <div class="kss-source kss-style">
-          Source: <code>utilities/mixins/menus/_outer-megamenu.scss</code>, line 3
+          Source: <code>elements/_images.scss</code>, line 3
         </div>
           </div>
   </article>

--- a/styleguide/item-elements-links.html
+++ b/styleguide/item-elements-links.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-elements-links">
             <span class="kss-title__ref">
-              6.3
+              6.4
               <span class="kss-title__permalink-hash">
                 Elements.Links
               </span>

--- a/styleguide/item-elements-lists.html
+++ b/styleguide/item-elements-lists.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-elements-lists">
             <span class="kss-title__ref">
-              6.4
+              6.5
               <span class="kss-title__permalink-hash">
                 Elements.Lists
               </span>

--- a/styleguide/item-elements-quote.html
+++ b/styleguide/item-elements-quote.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-elements-quote">
             <span class="kss-title__ref">
-              6.5
+              6.6
               <span class="kss-title__permalink-hash">
                 Elements.Quote
               </span>

--- a/styleguide/item-elements-tables.html
+++ b/styleguide/item-elements-tables.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-elements-tables">
             <span class="kss-title__ref">
-              6.6
+              6.7
               <span class="kss-title__permalink-hash">
                 Elements.Tables
               </span>

--- a/styleguide/item-elements-typography.html
+++ b/styleguide/item-elements-typography.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-elements-typography">
             <span class="kss-title__ref">
-              6.7
+              6.8
               <span class="kss-title__permalink-hash">
                 Elements.Typography
               </span>

--- a/styleguide/item-elements.html
+++ b/styleguide/item-elements.html
@@ -75,32 +75,38 @@
               </a>
             </li>
                       <li class="kss-nav__menu-item">
-              <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-links">
+              <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-images">
                 <span class="kss-nav__ref ">6.3</span
+                ><span class="kss-nav__name">Images</span>
+              </a>
+            </li>
+                      <li class="kss-nav__menu-item">
+              <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-links">
+                <span class="kss-nav__ref ">6.4</span
                 ><span class="kss-nav__name">Links</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-lists">
-                <span class="kss-nav__ref ">6.4</span
+                <span class="kss-nav__ref ">6.5</span
                 ><span class="kss-nav__name">Lists</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-quote">
-                <span class="kss-nav__ref ">6.5</span
+                <span class="kss-nav__ref ">6.6</span
                 ><span class="kss-nav__name">Quote</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-tables">
-                <span class="kss-nav__ref ">6.6</span
+                <span class="kss-nav__ref ">6.7</span
                 ><span class="kss-nav__name">Tables</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-typography">
-                <span class="kss-nav__ref ">6.7</span
+                <span class="kss-nav__ref ">6.8</span
                 ><span class="kss-nav__name">Typography</span>
               </a>
             </li>

--- a/styleguide/item-mixins-images-image-defaults.html
+++ b/styleguide/item-mixins-images-image-defaults.html
@@ -77,23 +77,23 @@
 <article role="main" class="kss-main">
 
   
-          <div id="kssref-mixins-menus-outter-megamenu" class="kss-section kss-section--depth-3 is-fullscreen">
+          <div id="kssref-mixins-images-image-defaults" class="kss-section kss-section--depth-3 is-fullscreen">
       <div class="kss-style">
                 <h3 class="kss-title kss-title--level-3">
-          <a class="kss-title__permalink" href="#kssref-mixins-menus-outter-megamenu">
+          <a class="kss-title__permalink" href="#kssref-mixins-images-image-defaults">
             <span class="kss-title__ref">
-              8.12.3
+              8.9.1
               <span class="kss-title__permalink-hash">
-                Mixins.Menus.outter-megamenu
+                Mixins.Images.image-defaults
               </span>
             </span>
-            @outer-megamenu
+            @image-defaults
           </a>
         </h3>
 
         
                   <div class="kss-description">
-            <p>@TODO Needs to be documented.</p>
+            <p>Default image styling to help with layout and responsiveness.</p>
 
           </div>
         
@@ -101,7 +101,7 @@
 
       
               <div class="kss-source kss-style">
-          Source: <code>utilities/mixins/menus/_outer-megamenu.scss</code>, line 3
+          Source: <code>utilities/mixins/images/_image-defaults.scss</code>, line 3
         </div>
           </div>
   </article>

--- a/styleguide/item-mixins-images.html
+++ b/styleguide/item-mixins-images.html
@@ -77,23 +77,23 @@
 <article role="main" class="kss-main">
 
   
-          <div id="kssref-mixins-menus-outter-megamenu" class="kss-section kss-section--depth-3 is-fullscreen">
+          <div id="kssref-mixins-images" class="kss-section kss-section--depth-2 is-fullscreen">
       <div class="kss-style">
-                <h3 class="kss-title kss-title--level-3">
-          <a class="kss-title__permalink" href="#kssref-mixins-menus-outter-megamenu">
+                <h2 class="kss-title kss-title--level-2">
+          <a class="kss-title__permalink" href="#kssref-mixins-images">
             <span class="kss-title__ref">
-              8.12.3
+              8.9
               <span class="kss-title__permalink-hash">
-                Mixins.Menus.outter-megamenu
+                Mixins.Images
               </span>
             </span>
-            @outer-megamenu
+            Images
           </a>
-        </h3>
+        </h2>
 
         
                   <div class="kss-description">
-            <p>@TODO Needs to be documented.</p>
+            <p>Mixins for Images</p>
 
           </div>
         
@@ -101,7 +101,7 @@
 
       
               <div class="kss-source kss-style">
-          Source: <code>utilities/mixins/menus/_outer-megamenu.scss</code>, line 3
+          Source: <code>utilities/mixins/images/index.scss</code>, line 3
         </div>
           </div>
   </article>

--- a/styleguide/item-mixins-links-external-link.html
+++ b/styleguide/item-mixins-links-external-link.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-links-external-link">
             <span class="kss-title__ref">
-              8.9.1
+              8.10.1
               <span class="kss-title__permalink-hash">
                 Mixins.Links.external-link
               </span>

--- a/styleguide/item-mixins-links-link.html
+++ b/styleguide/item-mixins-links-link.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-links-link">
             <span class="kss-title__ref">
-              8.9.2
+              8.10.2
               <span class="kss-title__permalink-hash">
                 Mixins.Links.link
               </span>

--- a/styleguide/item-mixins-links-more-link.html
+++ b/styleguide/item-mixins-links-more-link.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-links-more-link">
             <span class="kss-title__ref">
-              8.9.3
+              8.10.3
               <span class="kss-title__permalink-hash">
                 Mixins.Links.more-link
               </span>

--- a/styleguide/item-mixins-links.html
+++ b/styleguide/item-mixins-links.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-links">
             <span class="kss-title__ref">
-              8.9
+              8.10
               <span class="kss-title__permalink-hash">
                 Mixins.Links
               </span>

--- a/styleguide/item-mixins-lists-list-unstyled.html
+++ b/styleguide/item-mixins-lists-list-unstyled.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-lists-list-unstyled">
             <span class="kss-title__ref">
-              8.10.1
+              8.11.1
               <span class="kss-title__permalink-hash">
                 Mixins.Lists.list-unstyled
               </span>

--- a/styleguide/item-mixins-lists.html
+++ b/styleguide/item-mixins-lists.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-lists">
             <span class="kss-title__ref">
-              8.10
+              8.11
               <span class="kss-title__permalink-hash">
                 Mixins.Lists
               </span>

--- a/styleguide/item-mixins-menus-main-menu.html
+++ b/styleguide/item-mixins-menus-main-menu.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-menus-main-menu">
             <span class="kss-title__ref">
-              8.11.1
+              8.12.1
               <span class="kss-title__permalink-hash">
                 Mixins.Menus.main-menu
               </span>

--- a/styleguide/item-mixins-menus-megamenu.html
+++ b/styleguide/item-mixins-menus-megamenu.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-menus-megamenu">
             <span class="kss-title__ref">
-              8.11.2
+              8.12.2
               <span class="kss-title__permalink-hash">
                 Mixins.Menus.megamenu
               </span>

--- a/styleguide/item-mixins-menus-sidenav-sublist.html
+++ b/styleguide/item-mixins-menus-sidenav-sublist.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-menus-sidenav-sublist">
             <span class="kss-title__ref">
-              8.11.4
+              8.12.4
               <span class="kss-title__permalink-hash">
                 Mixins.Menus.sidenav-sublist
               </span>

--- a/styleguide/item-mixins-menus-subnav-list.html
+++ b/styleguide/item-mixins-menus-subnav-list.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-menus-subnav-list">
             <span class="kss-title__ref">
-              8.11.5
+              8.12.5
               <span class="kss-title__permalink-hash">
                 Mixins.Menus.subnav-list
               </span>

--- a/styleguide/item-mixins-menus.html
+++ b/styleguide/item-mixins-menus.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-menus">
             <span class="kss-title__ref">
-              8.11
+              8.12
               <span class="kss-title__permalink-hash">
                 Mixins.Menus
               </span>

--- a/styleguide/item-mixins-navigation-nav-border.html
+++ b/styleguide/item-mixins-navigation-nav-border.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-navigation-nav-border">
             <span class="kss-title__ref">
-              8.12.1
+              8.13.1
               <span class="kss-title__permalink-hash">
                 Mixins.Navigation.nav-border
               </span>

--- a/styleguide/item-mixins-navigation-nav-close.html
+++ b/styleguide/item-mixins-navigation-nav-close.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-navigation-nav-close">
             <span class="kss-title__ref">
-              8.12.2
+              8.13.2
               <span class="kss-title__permalink-hash">
                 Mixins.Navigation.nav-close
               </span>

--- a/styleguide/item-mixins-navigation-nav-overlay.html
+++ b/styleguide/item-mixins-navigation-nav-overlay.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-navigation-nav-overlay">
             <span class="kss-title__ref">
-              8.12.3
+              8.13.3
               <span class="kss-title__permalink-hash">
                 Mixins.Navigation.nav-overlay
               </span>

--- a/styleguide/item-mixins-navigation.html
+++ b/styleguide/item-mixins-navigation.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-navigation">
             <span class="kss-title__ref">
-              8.12
+              8.13
               <span class="kss-title__permalink-hash">
                 Mixins.Navigation
               </span>

--- a/styleguide/item-mixins-quote-quote.html
+++ b/styleguide/item-mixins-quote-quote.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-quote-quote">
             <span class="kss-title__ref">
-              8.13.1
+              8.14.1
               <span class="kss-title__permalink-hash">
                 Mixins.Quote.quote
               </span>

--- a/styleguide/item-mixins-quote.html
+++ b/styleguide/item-mixins-quote.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-quote">
             <span class="kss-title__ref">
-              8.13
+              8.14
               <span class="kss-title__permalink-hash">
                 Mixins.Quote
               </span>

--- a/styleguide/item-mixins-tables-table-borderless.html
+++ b/styleguide/item-mixins-tables-table-borderless.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-tables-table-borderless">
             <span class="kss-title__ref">
-              8.14.1
+              8.15.1
               <span class="kss-title__permalink-hash">
                 Mixins.Tables.table-borderless
               </span>

--- a/styleguide/item-mixins-tables-tables.html
+++ b/styleguide/item-mixins-tables-tables.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-tables-tables">
             <span class="kss-title__ref">
-              8.14.2
+              8.15.2
               <span class="kss-title__permalink-hash">
                 Mixins.Tables.tables
               </span>

--- a/styleguide/item-mixins-tables.html
+++ b/styleguide/item-mixins-tables.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-tables">
             <span class="kss-title__ref">
-              8.14
+              8.15
               <span class="kss-title__permalink-hash">
                 Mixins.Tables
               </span>

--- a/styleguide/item-mixins-typography-caption.html
+++ b/styleguide/item-mixins-typography-caption.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-caption">
             <span class="kss-title__ref">
-              8.15.1
+              8.16.1
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.caption
               </span>

--- a/styleguide/item-mixins-typography-credits.html
+++ b/styleguide/item-mixins-typography-credits.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-credits">
             <span class="kss-title__ref">
-              8.15.2
+              8.16.2
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.credits
               </span>

--- a/styleguide/item-mixins-typography-font-lead.html
+++ b/styleguide/item-mixins-typography-font-lead.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-font-lead">
             <span class="kss-title__ref">
-              8.15.3
+              8.16.3
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.font-lead
               </span>

--- a/styleguide/item-mixins-typography-font-smoothing.html
+++ b/styleguide/item-mixins-typography-font-smoothing.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-font-smoothing">
             <span class="kss-title__ref">
-              8.15.4
+              8.16.4
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.font-smoothing
               </span>

--- a/styleguide/item-mixins-typography-font-splash.html
+++ b/styleguide/item-mixins-typography-font-splash.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-font-splash">
             <span class="kss-title__ref">
-              8.15.5
+              8.16.5
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.font-splash
               </span>

--- a/styleguide/item-mixins-typography-h1.html
+++ b/styleguide/item-mixins-typography-h1.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h1">
             <span class="kss-title__ref">
-              8.15.6
+              8.16.6
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h1
               </span>

--- a/styleguide/item-mixins-typography-h2.html
+++ b/styleguide/item-mixins-typography-h2.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h2">
             <span class="kss-title__ref">
-              8.15.7
+              8.16.7
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h2
               </span>

--- a/styleguide/item-mixins-typography-h3.html
+++ b/styleguide/item-mixins-typography-h3.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h3">
             <span class="kss-title__ref">
-              8.15.8
+              8.16.8
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h3
               </span>

--- a/styleguide/item-mixins-typography-h4.html
+++ b/styleguide/item-mixins-typography-h4.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h4">
             <span class="kss-title__ref">
-              8.15.9
+              8.16.9
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h4
               </span>

--- a/styleguide/item-mixins-typography-h5.html
+++ b/styleguide/item-mixins-typography-h5.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h5">
             <span class="kss-title__ref">
-              8.15.10
+              8.16.10
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h5
               </span>

--- a/styleguide/item-mixins-typography-h6.html
+++ b/styleguide/item-mixins-typography-h6.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h6">
             <span class="kss-title__ref">
-              8.15.11
+              8.16.11
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h6
               </span>

--- a/styleguide/item-mixins-typography-headings.html
+++ b/styleguide/item-mixins-typography-headings.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-headings">
             <span class="kss-title__ref">
-              8.15.12
+              8.16.12
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.headings
               </span>

--- a/styleguide/item-mixins-typography-sans.html
+++ b/styleguide/item-mixins-typography-sans.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-sans">
             <span class="kss-title__ref">
-              8.15.13
+              8.16.13
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.sans
               </span>

--- a/styleguide/item-mixins-typography-serif.html
+++ b/styleguide/item-mixins-typography-serif.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-serif">
             <span class="kss-title__ref">
-              8.15.14
+              8.16.14
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.serif
               </span>

--- a/styleguide/item-mixins-typography-short-line-length.html
+++ b/styleguide/item-mixins-typography-short-line-length.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-short-line-length">
             <span class="kss-title__ref">
-              8.15.15
+              8.16.15
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.short-line-length
               </span>

--- a/styleguide/item-mixins-typography-slab.html
+++ b/styleguide/item-mixins-typography-slab.html
@@ -82,7 +82,7 @@
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-slab">
             <span class="kss-title__ref">
-              8.15.16
+              8.16.16
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.slab
               </span>

--- a/styleguide/item-mixins-typography.html
+++ b/styleguide/item-mixins-typography.html
@@ -82,7 +82,7 @@
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-typography">
             <span class="kss-title__ref">
-              8.15
+              8.16
               <span class="kss-title__permalink-hash">
                 Mixins.Typography
               </span>

--- a/styleguide/item-mixins.html
+++ b/styleguide/item-mixins.html
@@ -253,230 +253,242 @@
               </a>
             </li>
                       <li class="kss-nav__menu-item">
-              <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-links">
+              <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-images">
                 <span class="kss-nav__ref ">8.9</span
+                ><span class="kss-nav__name">Images</span>
+              </a>
+            </li>
+                      <li class="kss-nav__menu-item">
+              <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-images-image-defaults">
+                <span class="kss-nav__ref kss-nav__ref-child">8.9.1</span
+                ><span class="kss-nav__name">@image-defaults</span>
+              </a>
+            </li>
+                      <li class="kss-nav__menu-item">
+              <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-links">
+                <span class="kss-nav__ref ">8.10</span
                 ><span class="kss-nav__name">Links</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-links-external-link">
-                <span class="kss-nav__ref kss-nav__ref-child">8.9.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.10.1</span
                 ><span class="kss-nav__name">@external-link($external-link, $external-link-hover)</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-links-link">
-                <span class="kss-nav__ref kss-nav__ref-child">8.9.2</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.10.2</span
                 ><span class="kss-nav__name">@link</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-links-more-link">
-                <span class="kss-nav__ref kss-nav__ref-child">8.9.3</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.10.3</span
                 ><span class="kss-nav__name">@more-link($more-link, $more-link-hover)</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-lists">
-                <span class="kss-nav__ref ">8.10</span
+                <span class="kss-nav__ref ">8.11</span
                 ><span class="kss-nav__name">Lists</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-lists-list-unstyled">
-                <span class="kss-nav__ref kss-nav__ref-child">8.10.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.11.1</span
                 ><span class="kss-nav__name">@list-unstyled</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus">
-                <span class="kss-nav__ref ">8.11</span
+                <span class="kss-nav__ref ">8.12</span
                 ><span class="kss-nav__name">Menus</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus-main-menu">
-                <span class="kss-nav__ref kss-nav__ref-child">8.11.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.12.1</span
                 ><span class="kss-nav__name">@main-menu</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus-megamenu">
-                <span class="kss-nav__ref kss-nav__ref-child">8.11.2</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.12.2</span
                 ><span class="kss-nav__name">@megamenu</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus-outter-megamenu">
-                <span class="kss-nav__ref kss-nav__ref-child">8.11.3</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.12.3</span
                 ><span class="kss-nav__name">@outer-megamenu</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus-sidenav-sublist">
-                <span class="kss-nav__ref kss-nav__ref-child">8.11.4</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.12.4</span
                 ><span class="kss-nav__name">@sidenav-sublist</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus-subnav-list">
-                <span class="kss-nav__ref kss-nav__ref-child">8.11.5</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.12.5</span
                 ><span class="kss-nav__name">@sidenav-list</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-navigation">
-                <span class="kss-nav__ref ">8.12</span
+                <span class="kss-nav__ref ">8.13</span
                 ><span class="kss-nav__name">Navigation</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-navigation-nav-border">
-                <span class="kss-nav__ref kss-nav__ref-child">8.12.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.13.1</span
                 ><span class="kss-nav__name">@nav-border</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-navigation-nav-close">
-                <span class="kss-nav__ref kss-nav__ref-child">8.12.2</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.13.2</span
                 ><span class="kss-nav__name">@nav-close</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-navigation-nav-overlay">
-                <span class="kss-nav__ref kss-nav__ref-child">8.12.3</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.13.3</span
                 ><span class="kss-nav__name">@nav-overlay</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-quote">
-                <span class="kss-nav__ref ">8.13</span
+                <span class="kss-nav__ref ">8.14</span
                 ><span class="kss-nav__name">Quote</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-quote-quote">
-                <span class="kss-nav__ref kss-nav__ref-child">8.13.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.14.1</span
                 ><span class="kss-nav__name">@quote</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-tables">
-                <span class="kss-nav__ref ">8.14</span
+                <span class="kss-nav__ref ">8.15</span
                 ><span class="kss-nav__name">Tables</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-tables-table-borderless">
-                <span class="kss-nav__ref kss-nav__ref-child">8.14.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.15.1</span
                 ><span class="kss-nav__name">@table-borderless</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-tables-tables">
-                <span class="kss-nav__ref kss-nav__ref-child">8.14.2</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.15.2</span
                 ><span class="kss-nav__name">@tables</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography">
-                <span class="kss-nav__ref ">8.15</span
+                <span class="kss-nav__ref ">8.16</span
                 ><span class="kss-nav__name">Typography</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-caption">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.1</span
                 ><span class="kss-nav__name">@caption</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-credits">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.2</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.2</span
                 ><span class="kss-nav__name">@credits</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-font-lead">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.3</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.3</span
                 ><span class="kss-nav__name">@font-lead</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-font-smoothing">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.4</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.4</span
                 ><span class="kss-nav__name">@font-smoothing</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-font-splash">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.5</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.5</span
                 ><span class="kss-nav__name">@font-splash</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h1">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.6</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.6</span
                 ><span class="kss-nav__name">@h1</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h2">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.7</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.7</span
                 ><span class="kss-nav__name">@h2</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h3">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.8</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.8</span
                 ><span class="kss-nav__name">@h3</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h4">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.9</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.9</span
                 ><span class="kss-nav__name">@h4</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h5">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.10</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.10</span
                 ><span class="kss-nav__name">@h5</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h6">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.11</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.11</span
                 ><span class="kss-nav__name">@h6</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-headings">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.12</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.12</span
                 ><span class="kss-nav__name">@headings</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-sans">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.13</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.13</span
                 ><span class="kss-nav__name">@sans</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-serif">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.14</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.14</span
                 ><span class="kss-nav__name">@serif</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-short-line-length">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.15</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.15</span
                 ><span class="kss-nav__name">@short-line-length</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-slab">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.16</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.16</span
                 ><span class="kss-nav__name">@slab</span>
               </a>
             </li>

--- a/styleguide/section-elements.html
+++ b/styleguide/section-elements.html
@@ -75,32 +75,38 @@
               </a>
             </li>
                       <li class="kss-nav__menu-item">
-              <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-links">
+              <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-images">
                 <span class="kss-nav__ref ">6.3</span
+                ><span class="kss-nav__name">Images</span>
+              </a>
+            </li>
+                      <li class="kss-nav__menu-item">
+              <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-links">
+                <span class="kss-nav__ref ">6.4</span
                 ><span class="kss-nav__name">Links</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-lists">
-                <span class="kss-nav__ref ">6.4</span
+                <span class="kss-nav__ref ">6.5</span
                 ><span class="kss-nav__name">Lists</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-quote">
-                <span class="kss-nav__ref ">6.5</span
+                <span class="kss-nav__ref ">6.6</span
                 ><span class="kss-nav__name">Quote</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-tables">
-                <span class="kss-nav__ref ">6.6</span
+                <span class="kss-nav__ref ">6.7</span
                 ><span class="kss-nav__name">Tables</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-elements.html#kssref-elements-typography">
-                <span class="kss-nav__ref ">6.7</span
+                <span class="kss-nav__ref ">6.8</span
                 ><span class="kss-nav__name">Typography</span>
               </a>
             </li>
@@ -310,12 +316,108 @@ readers.</p>
           Source: <code>elements/helpers/_sr-only.scss</code>, line 5
         </div>
           </section>
+          <section id="kssref-elements-images" class="kss-section kss-section--depth-2 ">
+      <div class="kss-style">
+                <h2 class="kss-title kss-title--level-2">
+          <a class="kss-title__permalink" href="#kssref-elements-images">
+            <span class="kss-title__ref">
+              6.3
+              <span class="kss-title__permalink-hash">
+                Elements.Images
+              </span>
+            </span>
+            Images
+          </a>
+        </h2>
+
+                  <p class="kss-toolbar">
+                          <a href="#kssref-elements-images" data-kss-fullscreen="kssref-elements-images">
+                <span class="kss-toolbar__tooltip">Toggle full screen</span>
+                <svg class="off" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100%" height="100%" viewBox="0 0 64 64">
+                  <path class="kss-toolbar__icon-fill" d="M64 0v26l-10-10-12 12-6-6 12-12-10-10zM28 42l-12 12 10 10h-26v-26l10 10 12-12z"></path>
+                </svg>
+                <svg class="on" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100%" height="100%" viewBox="0 0 64 64">
+                  <path class="kss-toolbar__icon-fill" d="M28 36v26l-10-10-12 12-6-6 12-12-10-10zM64 6l-12 12 10 10h-26v-26l10 10 12-12z"></path>
+                </svg>
+              </a>
+              <a href="item-elements-images.html" target="_blank">
+                <span class="kss-toolbar__tooltip">Open in new window</span>
+                <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100%" height="100%" viewBox="0 0 64 64">
+                  <rect x="0" y="20" width="40" height="44" fill="#fff"/>
+                  <path class="kss-toolbar__icon-fill" d="M40,64l-40,0l0,-44l40,0l0,44Zm-36,-40l0,36l32,0l0,-36l-32,0Z"/>
+                  <rect class="kss-toolbar__icon-fill" x="0" y="20" width="40" height="10"/>
+                  <rect x="24" y="0" width="40" height="44" fill="#fff"/>
+                  <path class="kss-toolbar__icon-fill" d="M64,44l-40,0l0,-44l40,0l0,44Zm-36,-40l0,36l32,0l0,-36l-32,0Z"/>
+                  <rect class="kss-toolbar__icon-fill" x="24" y="0" width="40" height="10"/>
+                </svg>
+              </a>
+                        <a href="#kssref-elements-images" data-kss-guides="true">
+              <span class="kss-toolbar__tooltip">Toggle example guides</span>
+              <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100%" height="100%" viewBox="0 0 64 64">
+                <rect class="kss-toolbar__icon-fill" x="5" y="35" width="5" height="9"/>
+                <rect class="kss-toolbar__icon-fill" x="54" y="21" width="5" height="9"/>
+                <rect class="kss-toolbar__icon-fill" x="54" y="35" width="5" height="9"/>
+                <rect class="kss-toolbar__icon-fill" x="5" y="21" width="5" height="9"/>
+                <rect class="kss-toolbar__icon-fill" x="5" y="0" width="5" height="15"/>
+                <rect class="kss-toolbar__icon-fill" x="35" y="5" width="9" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="20" y="5" width="9" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="0" y="5" width="15" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="54" y="0" width="5" height="15"/>
+                <rect class="kss-toolbar__icon-fill" x="49" y="5" width="15" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="54" y="49" width="5" height="15"/>
+                <rect class="kss-toolbar__icon-fill" x="49" y="54" width="15" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="5" y="49" width="5" height="15"/>
+                <rect class="kss-toolbar__icon-fill" x="0" y="54" width="15" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="35" y="54" width="9" height="5"/>
+                <rect class="kss-toolbar__icon-fill" x="20" y="54" width="9" height="5"/>
+              </svg>
+            </a>
+            <a href="#kssref-elements-images" data-kss-markup="true">
+              <span class="kss-toolbar__tooltip">Toggle HTML markup</span>
+              <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100%" height="100%" viewBox="0 0 64 64">
+                <path class="kss-toolbar__icon-fill" d="M37.555,46.239l6.103,6.103l20.342,-20.342l-20.342,-20.342l-6.103,6.103l14.24,14.239l-14.24,14.239Z"/>
+                <path class="kss-toolbar__icon-fill" d="M26.445,17.761l-6.103,-6.103l-20.342,20.342l20.342,20.342l6.103,-6.103l-14.24,-14.239l14.24,-14.239Z"/>
+              </svg>
+            </a>
+          </p>
+        
+                  <div class="kss-description">
+            <p>Default styles for images.</p>
+
+          </div>
+        
+              </div>
+
+              <div class="kss-modifier__wrapper">
+          <div class="kss-modifier__heading kss-style">
+            Example          </div>
+
+          
+          <div class="kss-modifier__example">
+            <img src="../../../img/hero-banner.png" alt="Stanford University Columns">
+
+            <div class="kss-modifier__example-footer"></div>
+          </div>
+
+                  </div>
+                  <details class="kss-markup kss-style">
+            <summary>
+                              Markup: <code>../templates/elements/images/images.twig</code>
+                          </summary>
+            <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;img src=&quot;../../../img/hero-banner.png&quot; alt=&quot;Stanford University Columns&quot;&gt;
+</code></pre>
+          </details>
+              
+              <div class="kss-source kss-style">
+          Source: <code>elements/_images.scss</code>, line 3
+        </div>
+          </section>
           <section id="kssref-elements-links" class="kss-section kss-section--depth-2 ">
       <div class="kss-style">
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-elements-links">
             <span class="kss-title__ref">
-              6.3
+              6.4
               <span class="kss-title__permalink-hash">
                 Elements.Links
               </span>
@@ -436,7 +538,7 @@ readers.</p>
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-elements-lists">
             <span class="kss-title__ref">
-              6.4
+              6.5
               <span class="kss-title__permalink-hash">
                 Elements.Lists
               </span>
@@ -612,7 +714,7 @@ readers.</p>
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-elements-quote">
             <span class="kss-title__ref">
-              6.5
+              6.6
               <span class="kss-title__permalink-hash">
                 Elements.Quote
               </span>
@@ -722,7 +824,7 @@ readers.</p>
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-elements-tables">
             <span class="kss-title__ref">
-              6.6
+              6.7
               <span class="kss-title__permalink-hash">
                 Elements.Tables
               </span>
@@ -897,7 +999,7 @@ Modifier class available to remove tables borders.</p>
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-elements-typography">
             <span class="kss-title__ref">
-              6.7
+              6.8
               <span class="kss-title__permalink-hash">
                 Elements.Typography
               </span>

--- a/styleguide/section-elements.html
+++ b/styleguide/section-elements.html
@@ -395,17 +395,15 @@ readers.</p>
           
           <div class="kss-modifier__example">
             <img src="../../../img/hero-banner.png" alt="Stanford University Columns">
-
             <div class="kss-modifier__example-footer"></div>
           </div>
 
                   </div>
                   <details class="kss-markup kss-style">
             <summary>
-                              Markup: <code>../templates/elements/images/images.twig</code>
+                              Markup
                           </summary>
-            <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;img src=&quot;../../../img/hero-banner.png&quot; alt=&quot;Stanford University Columns&quot;&gt;
-</code></pre>
+            <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;img src=&quot;../../../img/hero-banner.png&quot; alt=&quot;Stanford University Columns&quot;&gt;</code></pre>
           </details>
               
               <div class="kss-source kss-style">

--- a/styleguide/section-mixins.html
+++ b/styleguide/section-mixins.html
@@ -253,230 +253,242 @@
               </a>
             </li>
                       <li class="kss-nav__menu-item">
-              <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-links">
+              <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-images">
                 <span class="kss-nav__ref ">8.9</span
+                ><span class="kss-nav__name">Images</span>
+              </a>
+            </li>
+                      <li class="kss-nav__menu-item">
+              <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-images-image-defaults">
+                <span class="kss-nav__ref kss-nav__ref-child">8.9.1</span
+                ><span class="kss-nav__name">@image-defaults</span>
+              </a>
+            </li>
+                      <li class="kss-nav__menu-item">
+              <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-links">
+                <span class="kss-nav__ref ">8.10</span
                 ><span class="kss-nav__name">Links</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-links-external-link">
-                <span class="kss-nav__ref kss-nav__ref-child">8.9.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.10.1</span
                 ><span class="kss-nav__name">@external-link($external-link, $external-link-hover)</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-links-link">
-                <span class="kss-nav__ref kss-nav__ref-child">8.9.2</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.10.2</span
                 ><span class="kss-nav__name">@link</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-links-more-link">
-                <span class="kss-nav__ref kss-nav__ref-child">8.9.3</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.10.3</span
                 ><span class="kss-nav__name">@more-link($more-link, $more-link-hover)</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-lists">
-                <span class="kss-nav__ref ">8.10</span
+                <span class="kss-nav__ref ">8.11</span
                 ><span class="kss-nav__name">Lists</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-lists-list-unstyled">
-                <span class="kss-nav__ref kss-nav__ref-child">8.10.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.11.1</span
                 ><span class="kss-nav__name">@list-unstyled</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus">
-                <span class="kss-nav__ref ">8.11</span
+                <span class="kss-nav__ref ">8.12</span
                 ><span class="kss-nav__name">Menus</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus-main-menu">
-                <span class="kss-nav__ref kss-nav__ref-child">8.11.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.12.1</span
                 ><span class="kss-nav__name">@main-menu</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus-megamenu">
-                <span class="kss-nav__ref kss-nav__ref-child">8.11.2</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.12.2</span
                 ><span class="kss-nav__name">@megamenu</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus-outter-megamenu">
-                <span class="kss-nav__ref kss-nav__ref-child">8.11.3</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.12.3</span
                 ><span class="kss-nav__name">@outer-megamenu</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus-sidenav-sublist">
-                <span class="kss-nav__ref kss-nav__ref-child">8.11.4</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.12.4</span
                 ><span class="kss-nav__name">@sidenav-sublist</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-menus-subnav-list">
-                <span class="kss-nav__ref kss-nav__ref-child">8.11.5</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.12.5</span
                 ><span class="kss-nav__name">@sidenav-list</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-navigation">
-                <span class="kss-nav__ref ">8.12</span
+                <span class="kss-nav__ref ">8.13</span
                 ><span class="kss-nav__name">Navigation</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-navigation-nav-border">
-                <span class="kss-nav__ref kss-nav__ref-child">8.12.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.13.1</span
                 ><span class="kss-nav__name">@nav-border</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-navigation-nav-close">
-                <span class="kss-nav__ref kss-nav__ref-child">8.12.2</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.13.2</span
                 ><span class="kss-nav__name">@nav-close</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-navigation-nav-overlay">
-                <span class="kss-nav__ref kss-nav__ref-child">8.12.3</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.13.3</span
                 ><span class="kss-nav__name">@nav-overlay</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-quote">
-                <span class="kss-nav__ref ">8.13</span
+                <span class="kss-nav__ref ">8.14</span
                 ><span class="kss-nav__name">Quote</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-quote-quote">
-                <span class="kss-nav__ref kss-nav__ref-child">8.13.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.14.1</span
                 ><span class="kss-nav__name">@quote</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-tables">
-                <span class="kss-nav__ref ">8.14</span
+                <span class="kss-nav__ref ">8.15</span
                 ><span class="kss-nav__name">Tables</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-tables-table-borderless">
-                <span class="kss-nav__ref kss-nav__ref-child">8.14.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.15.1</span
                 ><span class="kss-nav__name">@table-borderless</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-tables-tables">
-                <span class="kss-nav__ref kss-nav__ref-child">8.14.2</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.15.2</span
                 ><span class="kss-nav__name">@tables</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography">
-                <span class="kss-nav__ref ">8.15</span
+                <span class="kss-nav__ref ">8.16</span
                 ><span class="kss-nav__name">Typography</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-caption">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.1</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.1</span
                 ><span class="kss-nav__name">@caption</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-credits">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.2</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.2</span
                 ><span class="kss-nav__name">@credits</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-font-lead">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.3</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.3</span
                 ><span class="kss-nav__name">@font-lead</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-font-smoothing">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.4</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.4</span
                 ><span class="kss-nav__name">@font-smoothing</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-font-splash">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.5</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.5</span
                 ><span class="kss-nav__name">@font-splash</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h1">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.6</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.6</span
                 ><span class="kss-nav__name">@h1</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h2">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.7</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.7</span
                 ><span class="kss-nav__name">@h2</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h3">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.8</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.8</span
                 ><span class="kss-nav__name">@h3</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h4">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.9</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.9</span
                 ><span class="kss-nav__name">@h4</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h5">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.10</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.10</span
                 ><span class="kss-nav__name">@h5</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-h6">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.11</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.11</span
                 ><span class="kss-nav__name">@h6</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-headings">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.12</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.12</span
                 ><span class="kss-nav__name">@headings</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-sans">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.13</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.13</span
                 ><span class="kss-nav__name">@sans</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-serif">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.14</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.14</span
                 ><span class="kss-nav__name">@serif</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-short-line-length">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.15</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.15</span
                 ><span class="kss-nav__name">@short-line-length</span>
               </a>
             </li>
                       <li class="kss-nav__menu-item">
               <a class="kss-nav__menu-link" href="section-mixins.html#kssref-mixins-typography-slab">
-                <span class="kss-nav__ref kss-nav__ref-child">8.15.16</span
+                <span class="kss-nav__ref kss-nav__ref-child">8.16.16</span
                 ><span class="kss-nav__name">@slab</span>
               </a>
             </li>
@@ -1432,12 +1444,66 @@ when floating images alongside other content.</p>
           Source: <code>utilities/mixins/icon-grid/_icon-grid.scss</code>, line 3
         </div>
           </section>
+          <section id="kssref-mixins-images" class="kss-section kss-section--depth-2 ">
+      <div class="kss-style">
+                <h2 class="kss-title kss-title--level-2">
+          <a class="kss-title__permalink" href="#kssref-mixins-images">
+            <span class="kss-title__ref">
+              8.9
+              <span class="kss-title__permalink-hash">
+                Mixins.Images
+              </span>
+            </span>
+            Images
+          </a>
+        </h2>
+
+        
+                  <div class="kss-description">
+            <p>Mixins for Images</p>
+
+          </div>
+        
+              </div>
+
+      
+              <div class="kss-source kss-style">
+          Source: <code>utilities/mixins/images/index.scss</code>, line 3
+        </div>
+          </section>
+          <section id="kssref-mixins-images-image-defaults" class="kss-section kss-section--depth-3 ">
+      <div class="kss-style">
+                <h3 class="kss-title kss-title--level-3">
+          <a class="kss-title__permalink" href="#kssref-mixins-images-image-defaults">
+            <span class="kss-title__ref">
+              8.9.1
+              <span class="kss-title__permalink-hash">
+                Mixins.Images.image-defaults
+              </span>
+            </span>
+            @image-defaults
+          </a>
+        </h3>
+
+        
+                  <div class="kss-description">
+            <p>Default image styling to help with layout and responsiveness.</p>
+
+          </div>
+        
+              </div>
+
+      
+              <div class="kss-source kss-style">
+          Source: <code>utilities/mixins/images/_image-defaults.scss</code>, line 3
+        </div>
+          </section>
           <section id="kssref-mixins-links" class="kss-section kss-section--depth-2 ">
       <div class="kss-style">
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-links">
             <span class="kss-title__ref">
-              8.9
+              8.10
               <span class="kss-title__permalink-hash">
                 Mixins.Links
               </span>
@@ -1464,7 +1530,7 @@ when floating images alongside other content.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-links-external-link">
             <span class="kss-title__ref">
-              8.9.1
+              8.10.1
               <span class="kss-title__permalink-hash">
                 Mixins.Links.external-link
               </span>
@@ -1491,7 +1557,7 @@ when floating images alongside other content.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-links-link">
             <span class="kss-title__ref">
-              8.9.2
+              8.10.2
               <span class="kss-title__permalink-hash">
                 Mixins.Links.link
               </span>
@@ -1518,7 +1584,7 @@ when floating images alongside other content.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-links-more-link">
             <span class="kss-title__ref">
-              8.9.3
+              8.10.3
               <span class="kss-title__permalink-hash">
                 Mixins.Links.more-link
               </span>
@@ -1545,7 +1611,7 @@ when floating images alongside other content.</p>
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-lists">
             <span class="kss-title__ref">
-              8.10
+              8.11
               <span class="kss-title__permalink-hash">
                 Mixins.Lists
               </span>
@@ -1572,7 +1638,7 @@ when floating images alongside other content.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-lists-list-unstyled">
             <span class="kss-title__ref">
-              8.10.1
+              8.11.1
               <span class="kss-title__permalink-hash">
                 Mixins.Lists.list-unstyled
               </span>
@@ -1599,7 +1665,7 @@ when floating images alongside other content.</p>
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-menus">
             <span class="kss-title__ref">
-              8.11
+              8.12
               <span class="kss-title__permalink-hash">
                 Mixins.Menus
               </span>
@@ -1626,7 +1692,7 @@ when floating images alongside other content.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-menus-main-menu">
             <span class="kss-title__ref">
-              8.11.1
+              8.12.1
               <span class="kss-title__permalink-hash">
                 Mixins.Menus.main-menu
               </span>
@@ -1653,7 +1719,7 @@ when floating images alongside other content.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-menus-megamenu">
             <span class="kss-title__ref">
-              8.11.2
+              8.12.2
               <span class="kss-title__permalink-hash">
                 Mixins.Menus.megamenu
               </span>
@@ -1682,7 +1748,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-menus-outter-megamenu">
             <span class="kss-title__ref">
-              8.11.3
+              8.12.3
               <span class="kss-title__permalink-hash">
                 Mixins.Menus.outter-megamenu
               </span>
@@ -1709,7 +1775,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-menus-sidenav-sublist">
             <span class="kss-title__ref">
-              8.11.4
+              8.12.4
               <span class="kss-title__permalink-hash">
                 Mixins.Menus.sidenav-sublist
               </span>
@@ -1736,7 +1802,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-menus-subnav-list">
             <span class="kss-title__ref">
-              8.11.5
+              8.12.5
               <span class="kss-title__permalink-hash">
                 Mixins.Menus.subnav-list
               </span>
@@ -1763,7 +1829,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-navigation">
             <span class="kss-title__ref">
-              8.12
+              8.13
               <span class="kss-title__permalink-hash">
                 Mixins.Navigation
               </span>
@@ -1790,7 +1856,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-navigation-nav-border">
             <span class="kss-title__ref">
-              8.12.1
+              8.13.1
               <span class="kss-title__permalink-hash">
                 Mixins.Navigation.nav-border
               </span>
@@ -1817,7 +1883,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-navigation-nav-close">
             <span class="kss-title__ref">
-              8.12.2
+              8.13.2
               <span class="kss-title__permalink-hash">
                 Mixins.Navigation.nav-close
               </span>
@@ -1844,7 +1910,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-navigation-nav-overlay">
             <span class="kss-title__ref">
-              8.12.3
+              8.13.3
               <span class="kss-title__permalink-hash">
                 Mixins.Navigation.nav-overlay
               </span>
@@ -1871,7 +1937,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-quote">
             <span class="kss-title__ref">
-              8.13
+              8.14
               <span class="kss-title__permalink-hash">
                 Mixins.Quote
               </span>
@@ -1898,7 +1964,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-quote-quote">
             <span class="kss-title__ref">
-              8.13.1
+              8.14.1
               <span class="kss-title__permalink-hash">
                 Mixins.Quote.quote
               </span>
@@ -1925,7 +1991,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-tables">
             <span class="kss-title__ref">
-              8.14
+              8.15
               <span class="kss-title__permalink-hash">
                 Mixins.Tables
               </span>
@@ -1952,7 +2018,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-tables-table-borderless">
             <span class="kss-title__ref">
-              8.14.1
+              8.15.1
               <span class="kss-title__permalink-hash">
                 Mixins.Tables.table-borderless
               </span>
@@ -1979,7 +2045,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-tables-tables">
             <span class="kss-title__ref">
-              8.14.2
+              8.15.2
               <span class="kss-title__permalink-hash">
                 Mixins.Tables.tables
               </span>
@@ -2006,7 +2072,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h2 class="kss-title kss-title--level-2">
           <a class="kss-title__permalink" href="#kssref-mixins-typography">
             <span class="kss-title__ref">
-              8.15
+              8.16
               <span class="kss-title__permalink-hash">
                 Mixins.Typography
               </span>
@@ -2033,7 +2099,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-caption">
             <span class="kss-title__ref">
-              8.15.1
+              8.16.1
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.caption
               </span>
@@ -2060,7 +2126,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-credits">
             <span class="kss-title__ref">
-              8.15.2
+              8.16.2
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.credits
               </span>
@@ -2087,7 +2153,7 @@ options or for revealing lower-level site pages at a glance.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-font-lead">
             <span class="kss-title__ref">
-              8.15.3
+              8.16.3
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.font-lead
               </span>
@@ -2115,7 +2181,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-font-smoothing">
             <span class="kss-title__ref">
-              8.15.4
+              8.16.4
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.font-smoothing
               </span>
@@ -2142,7 +2208,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-font-splash">
             <span class="kss-title__ref">
-              8.15.5
+              8.16.5
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.font-splash
               </span>
@@ -2169,7 +2235,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h1">
             <span class="kss-title__ref">
-              8.15.6
+              8.16.6
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h1
               </span>
@@ -2196,7 +2262,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h2">
             <span class="kss-title__ref">
-              8.15.7
+              8.16.7
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h2
               </span>
@@ -2223,7 +2289,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h3">
             <span class="kss-title__ref">
-              8.15.8
+              8.16.8
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h3
               </span>
@@ -2250,7 +2316,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h4">
             <span class="kss-title__ref">
-              8.15.9
+              8.16.9
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h4
               </span>
@@ -2277,7 +2343,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h5">
             <span class="kss-title__ref">
-              8.15.10
+              8.16.10
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h5
               </span>
@@ -2304,7 +2370,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-h6">
             <span class="kss-title__ref">
-              8.15.11
+              8.16.11
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.h6
               </span>
@@ -2331,7 +2397,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-headings">
             <span class="kss-title__ref">
-              8.15.12
+              8.16.12
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.headings
               </span>
@@ -2358,7 +2424,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-sans">
             <span class="kss-title__ref">
-              8.15.13
+              8.16.13
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.sans
               </span>
@@ -2385,7 +2451,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-serif">
             <span class="kss-title__ref">
-              8.15.14
+              8.16.14
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.serif
               </span>
@@ -2412,7 +2478,7 @@ paragraph or quote.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-short-line-length">
             <span class="kss-title__ref">
-              8.15.15
+              8.16.15
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.short-line-length
               </span>
@@ -2440,7 +2506,7 @@ container.</p>
                 <h3 class="kss-title kss-title--level-3">
           <a class="kss-title__permalink" href="#kssref-mixins-typography-slab">
             <span class="kss-title__ref">
-              8.15.16
+              8.16.16
               <span class="kss-title__permalink-hash">
                 Mixins.Typography.slab
               </span>

--- a/templates/elements/images/images.json
+++ b/templates/elements/images/images.json
@@ -1,0 +1,4 @@
+{
+  "src": "../../../img/hero-banner.png",
+  "alt": "Stanford University Columns"
+}

--- a/templates/elements/images/images.json
+++ b/templates/elements/images/images.json
@@ -1,4 +1,0 @@
-{
-  "src": "../../../img/hero-banner.png",
-  "alt": "Stanford University Columns"
-}

--- a/templates/elements/images/images.twig
+++ b/templates/elements/images/images.twig
@@ -1,0 +1,1 @@
+<img src="{{ src }}" alt="{{ alt }}">

--- a/templates/elements/images/images.twig
+++ b/templates/elements/images/images.twig
@@ -1,1 +1,0 @@
-<img src="{{ src }}" alt="{{ alt }}">


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Set defaults for images (margins, padding, height, width, and display), to help with responsiveness and layout

# Needed By (Date)
- As soon as possible (would unblock some project work)

# Urgency
- N/A

# Steps to Test

1. Pull this branch
1. Ensure that the image element is displaying in the style guide and doing what added mixin suggests that it should

# Affected Projects or Products
- decanter
- stanford_basic (theme)
- suhumsci (theme), Archaeology project

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/ARCH-184
- https://github.com/SU-SWS/decanter/pull/175

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
