### PR TITLE
249: Change CTA icon to a variable

### DIFF
--- a/core/css/decanter.css
+++ b/core/css/decanter.css
@@ -1952,14 +1952,8 @@ button,
     text-decoration: none; }
   .su-cta--button-bottom .su-cta__img,
   .su-cta .su-cta__img {
-    display: block;
-    height: auto;
-    max-width: 100%;
-    margin: 0;
-    padding: 0;
     width: 100%;
     z-index: 0;
-    will-change: transform;
     transition: all .3s ease-out; }
   .su-cta--button-bottom .su-cta__button,
   .su-cta .su-cta__button {

--- a/core/css/decanter.css
+++ b/core/css/decanter.css
@@ -1942,6 +1942,14 @@ button,
   flex-direction: column;
   overflow: hidden;
   line-height: 0; }
+  .su-cta--button-bottom:hover .su-cta__img,
+  .su-cta:hover .su-cta__img {
+    -webkit-transform: scale(1.02, 1.02);
+            transform: scale(1.02, 1.02); }
+  .su-cta--button-bottom:hover .su-cta__button,
+  .su-cta:hover .su-cta__button {
+    background-color: #2e2d29;
+    text-decoration: none; }
   .su-cta--button-bottom .su-cta__img,
   .su-cta .su-cta__img {
     display: block;
@@ -1953,14 +1961,6 @@ button,
     z-index: 0;
     will-change: transform;
     transition: all .3s ease-out; }
-  .su-cta--button-bottom:hover .su-cta__img,
-  .su-cta:hover .su-cta__img {
-    -webkit-transform: scale(1.02, 1.02);
-            transform: scale(1.02, 1.02); }
-  .su-cta--button-bottom:hover .su-cta__button,
-  .su-cta:hover .su-cta__button {
-    background-color: #2e2d29;
-    text-decoration: none; }
   .su-cta--button-bottom .su-cta__button,
   .su-cta .su-cta__button {
     -moz-osx-font-smoothing: grayscale;
@@ -2012,14 +2012,12 @@ button,
   position: relative; }
   .su-cta--button-bottom-icon .su-cta__icon {
     display: block;
+    max-width: 30%;
     position: absolute;
     top: 50%;
     left: 50%;
     -webkit-transform: translate(-50%, calc(-50% - 2.65rem));
-            transform: translate(-50%, calc(-50% - 2.65rem));
-    color: #fff;
-    font-size: 4em;
-    text-shadow: 0 0 10px rgba(0, 0, 0, 0.4); }
+            transform: translate(-50%, calc(-50% - 2.65rem)); }
 
 .su-cta--button-center {
   position: relative; }

--- a/core/scss/components/cta/_cta.scss
+++ b/core/scss/components/cta/_cta.scss
@@ -25,17 +25,17 @@
 
   .su-cta__icon {
     display: block;
+    max-width: 30%;
     position: absolute;
     top: 50%;
     left: 50%;
     $_btn-height: $lead-font-size + 3rem; //height of the button
     $_shift: calc(#{-50%} - #{$_btn-height / 2}); //calculate the extra shift up for the icon to compensate for the button height
     transform: translate(-50%, $_shift);
-    color: #fff;
-    font-size: 4em;
-    text-shadow: 0 0 10px rgba(0, 0, 0, .4);
+    //color: #fff;
+    //font-size: 4em;
+    //text-shadow: 0 0 10px rgba(0, 0, 0, .4);
   }
-
 }
 
 .su-cta--button-center {

--- a/core/scss/components/cta/_cta.scss
+++ b/core/scss/components/cta/_cta.scss
@@ -32,9 +32,6 @@
     $_btn-height: $lead-font-size + 3rem; //height of the button
     $_shift: calc(#{-50%} - #{$_btn-height / 2}); //calculate the extra shift up for the icon to compensate for the button height
     transform: translate(-50%, $_shift);
-    //color: #fff;
-    //font-size: 4em;
-    //text-shadow: 0 0 10px rgba(0, 0, 0, .4);
   }
 }
 

--- a/core/scss/utilities/mixins/cta/_cta--button.scss
+++ b/core/scss/utilities/mixins/cta/_cta--button.scss
@@ -26,10 +26,8 @@
   }
 
   .su-cta__img {
-    @include image-defaults;
     width: 100%;
     z-index: 0;
-    will-change: transform;
     transition: all .3s ease-out;
   }
 

--- a/core/scss/utilities/mixins/cta/_cta--button.scss
+++ b/core/scss/utilities/mixins/cta/_cta--button.scss
@@ -7,19 +7,12 @@
 //
 // Style guide: Mixins.CTA.cta--button
 //
+
 @mixin cta--button {
   display: flex;
   flex-direction: column;
   overflow: hidden;
   line-height: 0;
-
-  .su-cta__img {
-    @include image-defaults;
-    width: 100%;
-    z-index: 0;
-    will-change: transform;
-    transition: all .3s ease-out;
-  }
 
   &:hover {
     .su-cta__img {
@@ -32,6 +25,14 @@
     }
   }
 
+  .su-cta__img {
+    @include image-defaults;
+    width: 100%;
+    z-index: 0;
+    will-change: transform;
+    transition: all .3s ease-out;
+  }
+
   .su-cta__button {
     @include button-big;
 
@@ -41,7 +42,6 @@
       width: 100%;
       z-index: 100;
     }
-
   }
 
   .su-cta__icon {

--- a/core/templates/components/cta/cta.json
+++ b/core/templates/components/cta/cta.json
@@ -3,5 +3,5 @@
   "text": "Button text",
   "src": "../../../img/hero-banner.png",
   "alt": "Alt text for CTA",
-  "icon": "fas fa-cat"
+  "icon_src": "../../../img/info.svg"
 }

--- a/core/templates/components/cta/cta.json
+++ b/core/templates/components/cta/cta.json
@@ -1,7 +1,8 @@
 {
   "link": "https://stanford.edu",
-  "text": "Button text",
-  "src": "../../../img/hero-banner.png",
-  "alt": "Alt text for CTA",
-  "icon_src": "../../../img/info.svg"
+  "button_text": "Button text",
+  "image_src": "../../../img/hero-banner.png",
+  "image_alt": "Alt text for CTA",
+  "icon_src": "../../../img/info.svg",
+  "icon_alt": "Alt text for icon"
 }

--- a/core/templates/components/cta/cta.twig
+++ b/core/templates/components/cta/cta.twig
@@ -4,28 +4,30 @@
  * CTA Component.
  *
  * Call to action component with clickable image and button.
+ *
  * Variants:
- *   - Default - Button at the bottom: With full-width button under the image
- *   - Button in the center: With button in the center of the clickable image
- *   - Button at the bottom with icon in the center: With full-width button under the image and an icon in the center of the image
+ * - .su-cta--button-bottom - Full-width button under the image
+ * - .su-cta--button-center - Button at the center of the image
+ * - .su-cta--button-bottom-icon - Full-width button under the image with an icon in the center of the image
  *
  * Available variables:
  * - attributes: For additional HTML attributes not already provided.
  * - modifier_class: Additional css classes to change look and behaviour.
- * - src: The href property of the image.
- * - alt: Alt text for the image.
+ * - image_src: The href property of the image.
+ * - image_alt: Alt text for the image.
  * - link: The href property of the CTA.
- * - text: The text label of the button.
+ * - button_text: The text label of the button.
  * - icon_src: The href property of the icon image.
+ * - icon_alt: Alt text for the icon image.
  */
 #}
 <a{{ attributes }} href="{{ link|default("https://stanford.edu") }}" class="su-cta {{ modifier_class }}">
-  <img class="su-cta__img" src="{{ src|default("../../../img/hero-banner.png") }}" alt="{{ alt|default("Please provide alt text") }}" />
+  <img src="{{ image_src|default("../../../img/hero-banner.png") }}" alt="{{ image_alt|default("Alt text for image") }}" class="su-cta__img" />
 
   {# CTA icon #}
   {% if icon_src is not empty %}
-    <img src="{{ icon_src }}" class="su-cta__icon" />
+    <img src="{{ icon_src }}" alt="{{ icon_alt|default("Alt text for icon") }}" class="su-cta__icon" role="presentation" />
   {% endif %}
 
-  <h2 class="su-cta__button">{{ text|default("Button text") }}</h2>
+  <h2 class="su-cta__button">{{ button_text|default("Button text") }}</h2>
 </a> <!-- cta end -->

--- a/core/templates/components/cta/cta.twig
+++ b/core/templates/components/cta/cta.twig
@@ -1,5 +1,31 @@
+{#
+/**
+ * @file
+ * CTA Component.
+ *
+ * Call to action component with clickable image and button.
+ * Variants:
+ *   - Default - Button at the bottom: With full-width button under the image
+ *   - Button in the center: With button in the center of the clickable image
+ *   - Button at the bottom with icon in the center: With full-width button under the image and an icon in the center of the image
+ *
+ * Available variables:
+ * - attributes: For additional HTML attributes not already provided.
+ * - modifier_class: Additional css classes to change look and behaviour.
+ * - src: The href property of the image.
+ * - alt: Alt text for the image.
+ * - link: The href property of the CTA.
+ * - text: The text label of the button.
+ * - icon_src: The href property of the icon image.
+ */
+#}
 <a{{ attributes }} href="{{ link|default("https://stanford.edu") }}" class="su-cta {{ modifier_class }}">
-  <img class="su-cta__img" src="{{ src|default("../../../img/hero-banner.png") }}" alt="{{ alt|default("Please provide alt text") }}">
-  <i class="su-cta__icon {{ icon|default("fas fa-cat") }}"></i>
+  <img class="su-cta__img" src="{{ src|default("../../../img/hero-banner.png") }}" alt="{{ alt|default("Please provide alt text") }}" />
+
+  {# CTA icon #}
+  {% if icon_src is not empty %}
+    <img src="{{ icon_src }}" class="su-cta__icon" />
+  {% endif %}
+
   <h2 class="su-cta__button">{{ text|default("Button text") }}</h2>
 </a> <!-- cta end -->


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed the icon to a variable (icon_src) since FontAwesome integration isn't ready; also pulled some CSS styles of components out of parent class wrapper in the mixin file.

# Needed By (Date)
- End of week

# Steps to Test

1. Pull this branch
1. Run grunt styleguide and check that the 3 CTA variants are there and the icon one is rendering a svg icon from the img directory.
2. Check that the cta.twig file is set up correctly

# Affected Projects or Products
- Decanter

# Associated Issues and/or People
- https://github.com/SU-SWS/decanter/issues/133
- https://github.com/SU-SWS/decanter/issues/249