### PR TITLE
make color change on hover & focus less abrupt

### DIFF
--- a/core/css/decanter.css
+++ b/core/css/decanter.css
@@ -1893,7 +1893,7 @@ button,
   text-align: center;
   text-decoration: none;
   width: 100%;
-  transition: all .25s ease-in-out; }
+  transition: background-color .25s ease-in-out, color .25s ease-in-out; }
   @media only screen and (min-width: 576px) {
     .su-button,
     button,

--- a/core/css/decanter.css
+++ b/core/css/decanter.css
@@ -1892,7 +1892,8 @@ button,
   outline: none;
   text-align: center;
   text-decoration: none;
-  width: 100%; }
+  width: 100%;
+  transition: all .25s ease-in-out; }
   @media only screen and (min-width: 576px) {
     .su-button,
     button,

--- a/core/scss/utilities/mixins/button/_button-primary.scss
+++ b/core/scss/utilities/mixins/button/_button-primary.scss
@@ -25,7 +25,7 @@
   text-align: center;
   text-decoration: none;
   width: 100%;
-  transition: all .25s ease-in-out;
+  transition: background-color .25s ease-in-out, color .25s ease-in-out;
 
   @media #{$breakpoint-sm} {
     width: auto;

--- a/core/scss/utilities/mixins/button/_button-primary.scss
+++ b/core/scss/utilities/mixins/button/_button-primary.scss
@@ -25,6 +25,7 @@
   text-align: center;
   text-decoration: none;
   width: 100%;
+  transition: all .25s ease-in-out;
 
   @media #{$breakpoint-sm} {
     width: auto;


### PR DESCRIPTION
While reviewing @sherakama's Card PR, I enjoyed the nice animation he added to the `action` link. Then I hovered over the card's button, and I found the color change very abrupt. I propose we add a little transition to buttons to make the color changes smoother.