### PR TITLE
Add region attribute variables to grid templates.

### DIFF
--- a/core/templates/layout/grid/four-column/molive/molive.twig
+++ b/core/templates/layout/grid/four-column/molive/molive.twig
@@ -22,7 +22,7 @@
     {# A centered max-width header region #}
     {% if header is not empty %}
     <header>
-      <div>
+      <div {{ region_attributes.header }}>
       {{ header }}
       </div>
     </header>
@@ -30,19 +30,19 @@
 
     {# Because of the responsive behaviour each column is required. #}
     <section>
-      <div>
+      <div {{ region_attributes.first }}>
         {{ first }}
       </div>
 
-      <div>
+      <div {{ region_attributes.second }}>
         {{ second }}
       </div>
 
-      <div>
+      <div {{ region_attributes.third }}>
         {{ third }}
       </div>
 
-      <div>
+      <div {{ region_attributes.fourth }}>
         {{ fourth }}
       </div>
     </section>
@@ -50,7 +50,7 @@
     {# Centered max-width footer region #}
     {% if footer is not empty %}
     <footer>
-      <div>
+      <div {{ region_attributes.footer }}>
       {{ footer }}
       </div>
     </footer>

--- a/core/templates/layout/grid/full-width/bricks/bricks.twig
+++ b/core/templates/layout/grid/full-width/bricks/bricks.twig
@@ -19,7 +19,7 @@
 
   {# Full width region #}
   {% if hero is not empty %}
-  <section class="layout__hero">
+  <section {{ region_attributes.hero }} class="layout__hero">
     {{ hero }}
   </section>
   {% endif %}
@@ -27,11 +27,11 @@
   {# Required two equal column centered content area. #}
   {% if first is not empty or second is not empty %}
   <section class="layout__columns">
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
 
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second}}
     </div>
   </section>
@@ -39,7 +39,7 @@
 
   {# Full width region #}
   {% if hero2 is not empty %}
-  <section class="layout__hero2">
+  <section {{ region_attributes.hero2 }} class="layout__hero2">
     {{ hero2 }}
   </section>
   {% endif %}
@@ -47,11 +47,11 @@
   {# Optional two equal column centered content area. #}
   {% if third is not empty or fourth is not empty %}
   <section class="layout__columns">
-    <div>
+    <div {{ region_attributes.third }}>
       {{ third }}
     </div>
 
-    <div>
+    <div {{ region_attributes.fourth }}>
       {{ fourth }}
     </div>
   </section>

--- a/core/templates/layout/grid/full-width/ibeam/ibeam.twig
+++ b/core/templates/layout/grid/full-width/ibeam/ibeam.twig
@@ -16,25 +16,25 @@
 <div{{ attributes }} class="layout layout-ibeam {{ modifier_class }}">
 
   {% if full_width is not empty %}
-  <div>
+  <div {{ region_attributes.full_width }}>
     {{ full_width }}
   </div>
   {% endif %}
 
   {% if content is not empty %}
-  <section>
+  <section {{ region_attributes.content }}>
     {{ content }}
   </section>
   {% endif %}
 
   {% if full_width2 is not empty %}
-  <div>
+  <div {{ region_attributes.full_width2 }}>
     {{ full_width2 }}
   </div>
   {% endif %}
 
   {% if content2 is not empty %}
-  <section>
+  <section {{ region_attributes.content2 }}>
     {{ content2 }}
   </section>
   {% endif %}

--- a/core/templates/layout/grid/one-column/basic/basic.twig
+++ b/core/templates/layout/grid/one-column/basic/basic.twig
@@ -14,19 +14,19 @@
 <div{{ attributes }} class="layout layout-basic {{ modifier_class }}">
 
   {% if header is not empty %}
-  <header>
+  <header {{ region_attributes.header }}>
     {{ header }}
   </header>
   {% endif %}
 
   {% if content is not empty %}
-  <section>
+  <section {{ region_attributes.content }}>
   {{ content}}
   </section>
   {% endif %}
 
   {% if footer is not empty %}
-  <footer>
+  <footer {{ region_attributes.footer }}>
     {{ footer }}
   </footer>
   {% endif %}

--- a/core/templates/layout/grid/one-column/centered-container/centered-container.twig
+++ b/core/templates/layout/grid/one-column/centered-container/centered-container.twig
@@ -17,7 +17,7 @@
  */
 #}
 <div{{attributes}} class="layout centered-container {{ modifier_class }}">
-  <div>
+  <div {{ region_attributes.content }}>
     {% block body %}
     {{ content }}
     {% endblock %}

--- a/core/templates/layout/grid/three-column/bars/bars.twig
+++ b/core/templates/layout/grid/three-column/bars/bars.twig
@@ -15,15 +15,15 @@
 <div{{ attributes }} class="layout layout-bars {{ modifier_class }}">
   <div>
     {% block body %}
-    <section>
+    <section {{ region_attributes.first }}>
       {{ first }}
     </section>
 
-    <section>
+    <section {{ region_attributes.second }}>
       {{ second }}
     </section>
 
-    <section>
+    <section {{ region_attributes.third }}>
       {{ third }}
     </section>
     {% endblock %}

--- a/core/templates/layout/grid/three-column/battleship/battleship.twig
+++ b/core/templates/layout/grid/three-column/battleship/battleship.twig
@@ -24,49 +24,49 @@
   <div>
     {% block body %}
     {% if first is not empty %}
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
     {% endif %}
 
     {% if second is not empty %}
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
     {% endif %}
 
     {% if third is not empty %}
-    <div>
+    <div {{ region_attributes.third }}>
       {{ third }}
     </div>
     {% endif %}
 
     {% if fourth is not empty %}
-    <div>
+    <div {{ region_attributes.fourth }}>
       {{ fourth }}
     </div>
     {% endif %}
 
     {% if fifth is not empty %}
-    <div>
+    <div {{ region_attributes.fifth }}>
       {{ fifth }}
     </div>
     {% endif %}
 
     {% if sixth is not empty %}
-    <div>
+    <div {{ region_attributes.sixth }}>
       {{ sixth }}
     </div>
     {% endif %}
 
     {% if seventh is not empty %}
-    <div>
+    <div {{ region_attributes.seventh }}>
       {{ seventh }}
     </div>
     {% endif %}
 
     {% if eighth is not empty %}
-    <div>
+    <div {{ region_attributes.eighth }}>
       {{ eighth }}
     </div>
     {% endif %}

--- a/core/templates/layout/grid/three-column/blastila/blastila.twig
+++ b/core/templates/layout/grid/three-column/blastila/blastila.twig
@@ -24,7 +24,7 @@
 <div{{ attributes }} class="layout layout-blastila {{ modifier_class }}">
 
   {% if header is not empty %}
-  <header>
+  <header {{ region_attributes.header }}>
     {{ header }}
   </header>
   {% endif %}
@@ -34,28 +34,28 @@
 
     {# Sidebar #}
     {% if sidebar is not empty %}
-    <aside>
+    <aside {{ region_attributes.sidebar }}>
       {{ sidebar }}
     </aside>
     {% endif %}
 
     {# Mini header area #}
     {% if first is not empty %}
-    <section>
+    <section {{ region_attributes.first }}>
       {{ first }}
     </section>
     {% endif %}
 
     {# Left content column #}
     {% if second is not empty %}
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
     {% endif %}
 
     {# Right content column #}
     {% if third is not empty %}
-    <div>
+    <div {{ region_attributes.third }}>
       {{ third }}
     </div>
     {% endif %}

--- a/core/templates/layout/grid/three-column/chess/chess.twig
+++ b/core/templates/layout/grid/three-column/chess/chess.twig
@@ -21,7 +21,7 @@
 <div{{ attributes }} class="layout layout-chess {{ modifier_class }}">
 
   {% if header is not empty %}
-  <header>
+  <header {{ region_attributes.header }}>
     {{ header }}
   </header>
   {% endif %}
@@ -29,37 +29,37 @@
   <section>
     {% block body %}
     {% if first is not empty %}
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
     {% endif %}
 
     {% if second is not empty %}
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
     {% endif %}
 
     {% if third is not empty %}
-    <div>
+    <div {{ region_attributes.third }}>
       {{ third }}
     </div>
     {% endif %}
 
     {% if fourth is not empty %}
-    <div>
+    <div {{ region_attributes.fourth }}>
       {{ fourth }}
     </div>
     {% endif %}
 
     {% if fifth is not empty %}
-    <div>
+    <div {{ region_attributes.fifth }}>
       {{ fifth }}
     </div>
     {% endif %}
 
     {% if sixth is not empty %}
-    <div>
+    <div {{ region_attributes.sixth }}>
       {{ sixth }}
     </div>
     {% endif %}
@@ -67,7 +67,7 @@
   </section>
 
   {% if footer is not empty %}
-  <footer>
+  <footer {{ region_attributes.footer }}>
     {{ footer }}
   </footer>
   {% endif %}

--- a/core/templates/layout/grid/three-column/cuttoner/cuttoner.twig
+++ b/core/templates/layout/grid/three-column/cuttoner/cuttoner.twig
@@ -23,32 +23,32 @@
   <div>
 
     {% if sidebar is not empty %}
-    <aside>
+    <aside {{ region_attributes.sidebar }}>
       {{ sidebar }}
     </aside>
     {% endif %}
 
     <section>
       {% if header is not empty %}
-      <header>
+      <header {{ region_attributes.header }}>
         {{ header }}
       </header>
       {% endif %}
 
       {% if first is not empty %}
-      <div>
+      <div {{ region_attributes.first }}>
         {{ first }}
       </div>
       {% endif %}
 
       {% if second is not empty %}
-      <div >
+      <div {{ region_attributes.second }}>
         {{ second }}
       </div>
       {% endif %}
 
       {% if footer is not empty %}
-      <footer>
+      <footer {{ region_attributes.footer }}>
         {{ footer }}
       </footer>
       {% endif %}

--- a/core/templates/layout/grid/three-column/percles/percles.twig
+++ b/core/templates/layout/grid/three-column/percles/percles.twig
@@ -25,31 +25,31 @@
 <div{{ attributes }} class="layout layout-percles {{ modifier_class }}">
   <div>
     {% if first is not empty %}
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
     {% endif %}
 
     {% if second is not empty %}
-    <header>
+    <header {{ region_attributes.second }}>
       {{ second }}
     </header>
     {% endif %}
 
     {% if third is not empty %}
-    <div>
+    <div {{ region_attributes.third }}>
       {{ third }}
     </div>
     {% endif %}
 
     {% if fourth is not empty %}
-    <div>
+    <div {{ region_attributes.fourth }}>
       {{ fourth }}
     </div>
     {% endif %}
 
     {% if fifth is not empty %}
-    <div>
+    <div {{ region_attributes.fifth }}>
       {{ fifth }}
     </div>
     {% endif %}

--- a/core/templates/layout/grid/three-column/robot/robot.twig
+++ b/core/templates/layout/grid/three-column/robot/robot.twig
@@ -21,25 +21,25 @@
   <div>
 
     {% if header is not empty %}
-    <header>
+    <header {{ region_attributes.header }}>
       {{ header }}
     </header>
     {% endif %}
 
     {% if first is not empty %}
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
     {% endif %}
 
     {% if second is not empty %}
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
     {% endif %}
 
     {% if third is not empty %}
-    <div>
+    <div {{ region_attributes.third }}>
       {{ third }}
     </div>
     {% endif %}

--- a/core/templates/layout/grid/three-column/space-invader/space-invader.twig
+++ b/core/templates/layout/grid/three-column/space-invader/space-invader.twig
@@ -20,25 +20,25 @@
   <div>
 
     {% if header is not empty %}
-    <header>
+    <header {{ region_attributes.header }}>
       {{ header }}
     </header>
     {% endif %}
 
     {% if first is not empty %}
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
     {% endif %}
 
     {% if second is not empty %}
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
     {% endif %}
 
     {% if third is not empty %}
-    <div>
+    <div {{ region_attributes.third }}>
       {{ third }}
     </div>
     {% endif %}

--- a/core/templates/layout/grid/three-column/sunset-delorean/sunset-delorean.twig
+++ b/core/templates/layout/grid/three-column/sunset-delorean/sunset-delorean.twig
@@ -19,26 +19,26 @@
 <div{{ attributes }} class="layout layout-sunset-delorean {{ modifier_class}}">
   <div>
     {% if header is not empty %}
-    <header>
+    <header {{ region_attributes.header }}>
       {{ header }}
     </header>
     {% endif %}
 
     {% if first is not empty %}
-    <section>
+    <section {{ region_attributes.first }}>
       {{ first }}
     </section>
     {% endif %}
 
     {% if second is not empty %}
-    <section>
+    <section {{ region_attributes.second }}>
       {{ second }}
     </section>
     {% endif %}
 
     {# Sidebar #}
     {% if sidebar is not empty %}
-    <aside>
+    <aside {{ region_attributes.sidebar }}>
       {{ sidebar }}
     </aside>
     {% endif %}

--- a/core/templates/layout/grid/three-column/thions/thions.twig
+++ b/core/templates/layout/grid/three-column/thions/thions.twig
@@ -16,23 +16,23 @@
 #}
 <div{{ attributes }} class="layout layout-thions {{ modifier_class }}">
   <div>
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
 
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
 
-    <div>
+    <div {{ region_attributes.third }}>
       {{ third }}
     </div>
 
-    <div>
+    <div {{ region_attributes.fourth }}>
       {{ fourth }}
     </div>
 
-    <div>
+    <div {{ region_attributes.fifth }}>
       {{ fifth }}
     </div>
   </div>

--- a/core/templates/layout/grid/three-column/valmer/valmer.twig
+++ b/core/templates/layout/grid/three-column/valmer/valmer.twig
@@ -17,27 +17,27 @@
 <div{{ attributes }} class="layout layout-valmer {{ modifier_class }}">
 
   {% if header is not empty %}
-  <header>
+  <header {{ region_attributes.header }}>
     {{ header }}
   </header>
   {% endif %}
 
   <section>
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
 
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
 
-    <div>
+    <div {{ region_attributes.third }}>
       {{ third }}
     </div>
   </section>
 
   {% if footer is not empty %}
-  <footer>
+  <footer {{ region_attributes.footer }}>
     {{ footer }}
   </footer>
   {% endif %}

--- a/core/templates/layout/grid/two-column/donies/donies.twig
+++ b/core/templates/layout/grid/two-column/donies/donies.twig
@@ -17,25 +17,25 @@
 <div{{ attributes }} class="layout layout-donies {{ modifier_class }}">
   {# Optional header region #}
   {% if header is not empty %}
-  <header>
+  <header {{ region_attributes.header }}>
     {{ header }}
   </header>
   {% endif %}
 
   {# Mandatory content region #}
   <section>
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
 
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
   </section>
 
   {# Optional footer region #}
   {% if footer is not empty %}
-  <footer>
+  <footer {{ region_attributes.footer }}>
     {{ footer }}
   </footer>
   {% endif %}

--- a/core/templates/layout/grid/two-column/frogger/frogger.twig
+++ b/core/templates/layout/grid/two-column/frogger/frogger.twig
@@ -18,25 +18,25 @@
 
   {# Optional Header #}
   {% if header is not empty %}
-  <header>
+  <header {{ region_attributes.header }}>
     {{ header }}
   </header>
   {% endif %}
 
   {# Required content section #}
   <section>
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
 
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
   </section>
 
   {# Optional centered container #}
   {% if middle is not empty %}
-  <div>
+  <div {{ region_attributes.middle }}>
     {{ middle }}
   </div>
   {% endif %}
@@ -44,11 +44,11 @@
   {# Optional third row #}
   {% if third is not empty %}
   <section>
-    <div>
+    <div {{ region_attributes.third }}>
       {{ third }}
     </div>
 
-    <div>
+    <div {{ region_attributes.fourth }}>
       {{ fourth }}
     </div>
   </section>
@@ -56,7 +56,7 @@
 
   {# Optional footer #}
   {% if footer is not empty %}
-  <footer>
+  <footer {{ region_attributes.footer }}>
     {{ footer }}
   </footer>
   {% endif %}

--- a/core/templates/layout/grid/two-column/pacman/pacman.twig
+++ b/core/templates/layout/grid/two-column/pacman/pacman.twig
@@ -17,25 +17,25 @@
 <div{{ attributes }} class="layout layout-pacman {{ modifier_class }}">
   {# Optional Header #}
   {% if header is not empty %}
-  <header>
+  <header {{ region_attributes.header }}>
     {{ header }}
   </header>
   {% endif %}
 
   {# Required content section #}
   <div>
-    <aside>
+    <aside {{ region_attributes.sidebar }}>
       {{ sidebar }}
     </aside>
 
-    <section>
+    <section {{ region_attributes.content }}>
       {{ content }}
     </section>
   </div>
 
   {# Optional footer #}
   {% if footer is not empty %}
-  <footer>
+  <footer {{ region_attributes.footer }}>
     {{ footer }}
   </footer>
   {% endif %}

--- a/core/templates/layout/grid/two-column/plakes/plakes.twig
+++ b/core/templates/layout/grid/two-column/plakes/plakes.twig
@@ -17,7 +17,7 @@
 <div{{ attributes }} class="layout layout-plakes {{ modifier_class }}">
   {# Optional Header #}
   {% if header is not empty %}
-  <header>
+  <header {{ region_attributes.header }}>
     {{ header }}
   </header>
   {% endif %}
@@ -25,12 +25,12 @@
   {# Grid Container #}
   <div>
     {# Manditory sidebar #}
-    <aside>
+    <aside {{ region_attributes.sidebar }}>
       {{ sidebar }}
     </aside>
 
     {# Manditory content #}
-    <section>
+    <section {{ region_attributes.content }}>
       {{ content }}
     </section>
   </div>

--- a/core/templates/layout/grid/two-column/toucan/toucan.twig
+++ b/core/templates/layout/grid/two-column/toucan/toucan.twig
@@ -10,12 +10,12 @@
   <div>
 
     {# Required column #}
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
 
     {# Required column #}
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
 

--- a/core/templates/layout/grid/two-column/trunks/trunks.twig
+++ b/core/templates/layout/grid/two-column/trunks/trunks.twig
@@ -16,11 +16,11 @@
 #}
 <div{{ attributes }} class="layout layout-trunks {{ modifier_class }}">
   <section>
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
 
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
   </section>

--- a/core/templates/layout/grid/two-column/wedge/wedge.twig
+++ b/core/templates/layout/grid/two-column/wedge/wedge.twig
@@ -19,11 +19,11 @@
 #}
 <div{{ attributes }} class="layout layout-wedge {{ modifier_class }}">
   <section>
-    <div>
+    <div {{ region_attributes.first }}>
       {{ first }}
     </div>
 
-    <div>
+    <div {{ region_attributes.second }}>
       {{ second }}
     </div>
   </section>


### PR DESCRIPTION
# Ready for review

# Summary
- Adds optional region wrapper attributes. 
- For integration into CMS systems that require markup be injected here
- Creates a standard in which to apply to components for nested region attributes

While working on the Drupal integration I came across a need to inject attributes around each of the variable regions. This is the standard they use. They use something called region_attributes and nest all of their attributes in that variable as an object. This allows me to add css classes, data attributes, ids, and more to the wrappers but does not introduce any extra markup for those that don't need them. We have come across the need for this kind of approach in the components with some nested attributes and would like to refactor to match.

