### PR TITLE
Small bugfix for mobile.

### DIFF
--- a/kss/builder/decanter/kss-assets/css/kss.css
+++ b/kss/builder/decanter/kss-assets/css/kss.css
@@ -1605,6 +1605,7 @@ body {
       margin: 0; }
 
 .kss-markup {
+  overflow: scroll;
   margin: 30px 0;
   border: 1px solid #ccc; }
   .kss-markup[open] summary {

--- a/kss/builder/decanter/scss/_markup-source.scss
+++ b/kss/builder/decanter/scss/_markup-source.scss
@@ -1,4 +1,5 @@
 .kss-markup {
+  overflow: scroll;
   margin: $kss-vertical-rhythm 0;
   border: 1px solid #ccc;
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Small bugfix for mobile screens where overflow was causing a right side gap.
![screen shot 2019-02-07 at 8 59 11 pm](https://user-images.githubusercontent.com/550602/52459672-692a4500-2b1b-11e9-908f-0dee7e56998e.png)

# Needed By (Date)
- Whenever

# Urgency
- low

# Steps to Test

1. View any inside page on `decanter.stanford.edu` with a mobile screen size (iphone or pixel)
2. Check out this branch and compile locally
3. View any inside page on your local dev and see gap gone

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)