### PR TITLE
Sticky alternative.

### DIFF
--- a/core/scss/components/global-footer/_global-footer--sticky.scss
+++ b/core/scss/components/global-footer/_global-footer--sticky.scss
@@ -1,0 +1,10 @@
+@charset "UTF-8";
+
+// To use this variant you must apply the sticky-footer mixin to the body tag
+// with this variant class as the input parameter..
+//
+// eg:
+// body {
+//  @include sticky-footer("> .global-footer--sticky")
+// }
+//

--- a/core/scss/components/global-footer/_global-footer.scss
+++ b/core/scss/components/global-footer/_global-footer.scss
@@ -5,6 +5,8 @@
 //
 // Global footer element as specified by the Identity Guidelines.
 //
+// .global-footer--sticky - Stick footer to the bottom of the screen.
+//
 // Markup: ../../templates/components/global-footer/global-footer.twig
 //
 // Style guide: Components.Global Footer

--- a/core/scss/components/global-footer/index.scss
+++ b/core/scss/components/global-footer/index.scss
@@ -5,4 +5,5 @@
 ///
 
 @import
+  'global-footer--sticky',
   'global-footer';

--- a/core/scss/utilities/mixins/layout/_sticky-footer.scss
+++ b/core/scss/utilities/mixins/layout/_sticky-footer.scss
@@ -20,7 +20,7 @@
 // Style guide: Mixins.Layout.Sticky Footer
 //
 
-@mixin sticky-footer($selector: '> .global-footer') {
+@mixin sticky-footer($selector: '> .global-footer--sticky') {
   @include padding(0);
   @include margin(0);
 

--- a/kss/builder/decanter/kss-assets/css/kss.css
+++ b/kss/builder/decanter/kss-assets/css/kss.css
@@ -867,7 +867,7 @@ body {
   -webkit-box-direction: normal;
       -ms-flex-direction: column;
           flex-direction: column; }
-  body > .global-footer {
+  body > .global-footer--sticky {
     margin-top: auto; }
   html {
     display: -webkit-box;


### PR DESCRIPTION
@stocker,

Would something like this allow you to stick the whole footer to the bottom of the page?

Instead of targeting the `global-footer` component itself, we pull out the stickiness into its own CSS class that you can add to any element you want as your footer container. This method does not have the global footer as sticky by default but does give you the flexibility to change what you want as stuck. 