### PR TITLE
Remove ID from brand-bar component

### DIFF
--- a/core/templates/components/brand-bar/brand-bar.twig
+++ b/core/templates/components/brand-bar/brand-bar.twig
@@ -14,6 +14,6 @@
  * - modifier_class: Additional css classes to change look and behaviour.
  */
 #}
-<section id="su-brand-bar" class="su-brand-bar {{ modifier_class }}">
+<section class="su-brand-bar {{ modifier_class }}">
   <div class="su-brand-bar__container"><a {{- attributes }} class="su-brand-bar__logo" href="https://stanford.edu">Stanford University</a></div>
 </section>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Get rid of brand bar ID. There's really no need for it and it affects our accessibility audit score due to multiple same ID in the styleguide site.

# Needed By (Date)
- Before v5 release

# Steps to Test

1. Pull this branch and run grunt styleguide.
2. Check that the rendered brand bars no longer have IDs

# Affected Projects or Products
- Decanter

# Associated Issues and/or People
- https://github.com/SU-SWS/decanter/issues/327
- https://github.com/SU-SWS/decanter/issues/314