### PR TITLE
Refactor site-search so the icon can be turned into inline CSS by Webpack

### DIFF
--- a/core/css/decanter.css
+++ b/core/css/decanter.css
@@ -8709,9 +8709,9 @@ a {
   -moz-osx-font-smoothing: grayscale;
   padding: 0.6rem 2rem;
   display: inline-block;
-  height: 40px;
+  height: 4rem;
   max-width: 100%;
-  border-radius: 30px;
+  border-radius: 3rem;
   font-size: 1.6rem; }
   .su-site-search__input::-webkit-input-placeholder {
     color: #2e2d29;
@@ -8743,10 +8743,10 @@ a {
   background: url("../img/icon-search.svg") no-repeat 0 0;
   opacity: .6;
   position: absolute;
-  top: 11px;
-  right: 12px;
-  width: 2.8rem;
-  height: 2.8rem; }
+  top: 1.1rem;
+  right: 1.2rem;
+  width: 24px;
+  height: 25px; }
   .su-site-search__submit:hover, .su-site-search__submit:active, .su-site-search__submit:focus {
     background-color: transparent;
     opacity: 1; }

--- a/core/css/decanter.css
+++ b/core/css/decanter.css
@@ -8744,16 +8744,18 @@ a {
   margin-top: 0;
   margin-right: 0;
   margin-bottom: 0;
-  background-color: transparent;
+  background: url("../img/icon-search.svg") no-repeat 0 0;
   opacity: .6;
   position: absolute;
+  overflow: hidden;
+  width: auto;
+  height: 2.8rem;
   top: 11px;
-  right: 12px;
-  width: auto; }
-  .su-site-search__submit img {
-    display: inline-block;
-    max-width: 24px;
-    max-height: 24px; }
+  right: 12px; }
+  .su-site-search__submit p {
+    opacity: 0;
+    width: 3rem;
+    height: 2.8rem; }
   .su-site-search__submit:hover, .su-site-search__submit:active, .su-site-search__submit:focus {
     background-color: transparent;
     opacity: 1; }

--- a/core/css/decanter.css
+++ b/core/css/decanter.css
@@ -8743,15 +8743,10 @@ a {
   background: url("../img/icon-search.svg") no-repeat 0 0;
   opacity: .6;
   position: absolute;
-  overflow: hidden;
-  width: auto;
-  height: 2.8rem;
   top: 11px;
-  right: 12px; }
-  .su-site-search__submit p {
-    opacity: 0;
-    width: 3rem;
-    height: 2.8rem; }
+  right: 12px;
+  width: 2.8rem;
+  height: 2.8rem; }
   .su-site-search__submit:hover, .su-site-search__submit:active, .su-site-search__submit:focus {
     background-color: transparent;
     opacity: 1; }

--- a/core/scss/components/site-search/_site-search.scss
+++ b/core/scss/components/site-search/_site-search.scss
@@ -37,17 +37,19 @@
   @include padding(0);
   @include margin(0 0 0 null);
 
-  background-color: transparent;
+  background: url("#{$image-path}/icon-search.svg") no-repeat 0 0;
   opacity: .6;
   position: absolute;
+  overflow: hidden;
+  width: auto;
+  height: 2.8rem;
   top: 11px;
   right: 12px;
-  width: auto;
 
-  img {
-    display: inline-block;
-    max-width: 24px;
-    max-height: 24px;
+  p {
+    opacity: 0;
+    width: 3rem;
+    height: 2.8rem;
   }
 
   &:hover,

--- a/core/scss/components/site-search/_site-search.scss
+++ b/core/scss/components/site-search/_site-search.scss
@@ -18,9 +18,9 @@
   @include padding(.6rem 2rem);
 
   display: inline-block;
-  height: 40px;
+  height: 4rem;
   max-width: 100%;
-  border-radius: 30px;
+  border-radius: 3rem;
   font-size: 1.6rem;
 
   &::placeholder {
@@ -40,10 +40,10 @@
   background: url("#{$image-path}/icon-search.svg") no-repeat 0 0;
   opacity: .6;
   position: absolute;
-  top: 11px;
-  right: 12px;
-  width: 2.8rem;
-  height: 2.8rem;
+  top: 1.1rem;
+  right: 1.2rem;
+  width: 24px;
+  height: 25px;
 
   &:hover,
   &:active,

--- a/core/scss/components/site-search/_site-search.scss
+++ b/core/scss/components/site-search/_site-search.scss
@@ -40,17 +40,10 @@
   background: url("#{$image-path}/icon-search.svg") no-repeat 0 0;
   opacity: .6;
   position: absolute;
-  overflow: hidden;
-  width: auto;
-  height: 2.8rem;
   top: 11px;
   right: 12px;
-
-  p {
-    opacity: 0;
-    width: 3rem;
-    height: 2.8rem;
-  }
+  width: 2.8rem;
+  height: 2.8rem;
 
   &:hover,
   &:active,

--- a/core/templates/components/site-search/site-search.json
+++ b/core/templates/components/site-search/site-search.json
@@ -3,6 +3,5 @@
   "method": "get",
   "search_label": "Search this site",
   "placeholder": "Search this site",
-  "search_input_name": "search-field",
-  "search_icon_src": "../../../img/icon-search.svg"
+  "search_input_name": "search-field"
 }

--- a/core/templates/components/site-search/site-search.twig
+++ b/core/templates/components/site-search/site-search.twig
@@ -15,7 +15,6 @@
  * - input_attributes: Additional HTML attributes for the search input field
  * - placeholder: Placeholder text for the search input field
  * - button_attributes: Additional HTML attributes for the submit button
- * - search_icon_src: The href property of the search icon image
  * - additional_fields: Any additional fields for the search form, e.g., hidden input fields
  *
  */
@@ -24,7 +23,7 @@
  <form action="{{ action }}" method="{{ method }}" accept-charset="UTF-8">
   <label class="su-site-search__sr-label" for="{{ search_input_name|default('search-field') }}">{{ search_label|default('Search this site') }}</label>
   <input {{- input_attributes }} type="text" id="{{ search_input_name|default('search-field') }}" name="{{ search_input_name|default('search-field') }}" class="su-site-search__input" placeholder="{{- placeholder -}}" maxlength="128">
-  <button {{- button_attributes }} type="submit" name="submit" class="su-site-search__submit" aria-label="Search"><img src="{{ search_icon_src }}" alt="Search button" /></button>
+  <button {{- button_attributes }} type="submit" name="submit" class="su-site-search__submit" aria-label="Search"><p>{{ search_label|default('Search this site') }}</p></button>
   {#- Any additional eg. hidden input fields -#}
   {{- additional_fields -}}
  </form>

--- a/core/templates/components/site-search/site-search.twig
+++ b/core/templates/components/site-search/site-search.twig
@@ -23,7 +23,7 @@
  <form action="{{ action }}" method="{{ method }}" accept-charset="UTF-8">
   <label class="su-site-search__sr-label" for="{{ search_input_name|default('search-field') }}">{{ search_label|default('Search this site') }}</label>
   <input {{- input_attributes }} type="text" id="{{ search_input_name|default('search-field') }}" name="{{ search_input_name|default('search-field') }}" class="su-site-search__input" placeholder="{{- placeholder -}}" maxlength="128">
-  <button {{- button_attributes }} type="submit" name="submit" class="su-site-search__submit" aria-label="Search"><p>{{ search_label|default('Search this site') }}</p></button>
+  <button {{- button_attributes }} type="submit" name="submit" class="su-site-search__submit su-sr-only-text" aria-label="Search">Submit Search</button>
   {#- Any additional eg. hidden input fields -#}
   {{- additional_fields -}}
  </form>

--- a/core/templates/components/site-search/site-search.twig
+++ b/core/templates/components/site-search/site-search.twig
@@ -12,9 +12,11 @@
  * - method: Method of the form
  * - search_label: Custom screen reader label
  * - search_input_name: Name for the search input field. Also used as the ID of the search input field and the "for" attribute of the label.
- * - input_attributes: Additional HTML attributes for the search input field
+ * - search_input_attributes: Additional HTML attributes for the search input field
  * - placeholder: Placeholder text for the search input field
- * - button_attributes: Additional HTML attributes for the submit button
+ * - search_button_attributes: Additional HTML attributes for the submit button
+ * - search_button_name: The name for the form element. Defaults to 'search'
+ * - search_button_text: The user facing text for the button. Defaults to 'Submit Search'
  * - additional_fields: Any additional fields for the search form, e.g., hidden input fields
  *
  */
@@ -22,8 +24,8 @@
 <div {{- attributes }} class="su-site-search {{ modifier_class }}" role="search">
  <form action="{{ action }}" method="{{ method }}" accept-charset="UTF-8">
   <label class="su-site-search__sr-label" for="{{ search_input_name|default('search-field') }}">{{ search_label|default('Search this site') }}</label>
-  <input {{- input_attributes }} type="text" id="{{ search_input_name|default('search-field') }}" name="{{ search_input_name|default('search-field') }}" class="su-site-search__input" placeholder="{{- placeholder -}}" maxlength="128">
-  <button {{- button_attributes }} type="submit" name="submit" class="su-site-search__submit su-sr-only-text" aria-label="Search">Submit Search</button>
+  <input {{- search_input_attributes }} type="text" id="{{ search_input_name|default('search-field') }}" name="{{ search_input_name|default('search-field') }}" class="su-site-search__input" placeholder="{{- placeholder -}}" maxlength="128">
+  <button {{- search_button_attributes }} type="submit" name="{{ search_button_name|default('search') }}" class="su-site-search__submit su-sr-only-text" aria-label="Search">{{ search_button_text|default('Submit Search') }}</button>
   {#- Any additional eg. hidden input fields -#}
   {{- additional_fields -}}
  </form>

--- a/kss/builder/decanter/kss-assets/css/kss.css
+++ b/kss/builder/decanter/kss-assets/css/kss.css
@@ -1878,7 +1878,7 @@ ol.linenums {
   font-weight: normal;
   color: #56554d; }
 
-#kssref-components-site-search .kss-modifier__example {
+#kssref-components-site-search .kss-modifier__wrapper {
   max-width: 40rem; }
 
 #kssref-components-skiplinks .kss-modifier__example {

--- a/kss/builder/decanter/kss-assets/css/kss.css
+++ b/kss/builder/decanter/kss-assets/css/kss.css
@@ -1878,6 +1878,9 @@ ol.linenums {
   font-weight: normal;
   color: #56554d; }
 
+#kssref-components-site-search .kss-modifier__example {
+  max-width: 40rem; }
+
 #kssref-components-skiplinks .kss-modifier__example {
   z-index: 11222; }
 

--- a/kss/builder/decanter/scss/_site-search.scss
+++ b/kss/builder/decanter/scss/_site-search.scss
@@ -1,0 +1,9 @@
+@charset 'UTF-8';
+
+// The site-search component
+
+#kssref-components-site-search {
+  .kss-modifier__example {
+    max-width: 40rem;
+  }
+}

--- a/kss/builder/decanter/scss/_site-search.scss
+++ b/kss/builder/decanter/scss/_site-search.scss
@@ -3,7 +3,7 @@
 // The site-search component
 
 #kssref-components-site-search {
-  .kss-modifier__example {
+  .kss-modifier__wrapper {
     max-width: 40rem;
   }
 }

--- a/kss/builder/decanter/scss/kss.scss
+++ b/kss/builder/decanter/scss/kss.scss
@@ -55,5 +55,6 @@
   'prettify',
   'print',
   'sidebar',
+  'site-search',
   'skiplinks',
   'toolbar';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Refactor the site-search component so that the `<img>` tag that's wrapped by the submit `<button>` is replaced with screen reader text, and render the icon as a background image on the `<button>`. That will allow Webpack to parse the icon and embed it directly in the css.
- Add a max-width in the styleguide scss which makes it look more "realistic" for the styleguide site.

# Needed By (Date)
- Before v.5

# Urgency
- ASAP

# Steps to Test

1. Pull this branch and run `grunt styleguide`
2. Check that in the site search component, the magnifying glass icon, is functioning as a button and look the same as the one on the current website build.
3. Check if it meets accessibility requirements.

# Affected Projects or Products
- Decanter

# Associated Issues and/or People
- #334 
- This is requested by @JBCSU due to her work on Webpack #334 