### PR TITLE
Remove reference to search icon in main-nav files

### DIFF
--- a/core/templates/components/main-nav/main-nav.json
+++ b/core/templates/components/main-nav/main-nav.json
@@ -108,7 +108,6 @@
     "method": "get",
     "search_label": "Search Stanford sites",
     "placeholder": "Search Stanford sites",
-    "search_input_name": "q",
-    "search_icon_src": "/img/icon-search.svg"
+    "search_input_name": "q"
   }
 }

--- a/core/templates/components/main-nav/main-nav.twig
+++ b/core/templates/components/main-nav/main-nav.twig
@@ -59,8 +59,7 @@
         "method": mobile_search.method,
         "search_label": mobile_search.search_label,
         "placeholder": mobile_search.placeholder,
-        "search_input_name": mobile_search.search_input_name,
-        "search_icon_src": mobile_search.search_icon_src
+        "search_input_name": mobile_search.search_input_name
       }
       only
     %}

--- a/core/templates/core/fonts/fonts.twig
+++ b/core/templates/core/fonts/fonts.twig
@@ -54,8 +54,8 @@
 </div>
 
 <div class="su-sanskrit">
-  <h2>Noto Sans</h2>
-  <p class="su-font-lead">Noto Sans is a secondary font.</p>
+  <h2>Noto Sans Devanagari (Sanskrit) Subset</h2>
+  <p class="su-font-lead">Noto Sans is a secondary font. It should only be used when Sanskrit font support is needed.</p>
   <h3>Style Variations</h3>
   <div style="font-weight: 400; font-style: normal;">Regular</div>
   <div style="font-weight: 400; font-style: italic;">Regular Italic</div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- We changed the icon in site-search button to background image. Now we need to remove the reference to the icon image in main-nav.twig and json.
- Added a little documentation for Noto Sans that it's the Sanskrit subset and should only be used when one needs Sanskrit support.

# Needed By (Date)
- Before v5

# Urgency
- ASAP 

# Steps to Test

1. Pull this branch and run grunt styleguide
2. Check that the .su-main-nav--mobile-search variant looks ok when in xs-md breakpoints. 
3. Check that the reference to the search icon has been removed in main-nav.twig and json.
4. Check that the added documentation under Fonts - Noto Sans is ok

# Affected Projects or Products
- Decanter

# Associated Issues and/or People
- @JBCSU 
- #334 