### PR TITLE
add openNav, closeNav, openSubnav, closeSubnav events

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,7 @@
     }
   },
   rules: {
-    max-len: [2, 80, 2, {"ignoreUrls": true}],
+    max-len: [2, 120, 2, {"ignoreUrls": true}],
     array-bracket-spacing: [2, "never"],
     block-scoped-var: 2,
     brace-style: [2, "stroustrup", {"allowSingleLine": true}],

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -30,6 +30,7 @@ rules:
   leading-zero:
     - 1
     - include: true
+  max-line-length: 120
   mixins-before-declarations: 0
   name-format: 0
   nesting-depth:

--- a/core/dist/js/decanter.js
+++ b/core/dist/js/decanter.js
@@ -112,12 +112,14 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "default", function() { return Nav; });
 /* harmony import */ var _globals__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./globals */ "./core/src/js/components/main-nav/globals.js");
 /* harmony import */ var _utilities_keyboard__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../utilities/keyboard */ "./core/src/js/utilities/keyboard.js");
-/* harmony import */ var _NavItem__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./NavItem */ "./core/src/js/components/main-nav/NavItem.js");
+/* harmony import */ var _utilities_events__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../utilities/events */ "./core/src/js/utilities/events.js");
+/* harmony import */ var _NavItem__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./NavItem */ "./core/src/js/components/main-nav/NavItem.js");
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
 
 
 
@@ -160,7 +162,7 @@ function () {
     this.topNav = this.getTopNav(); // If this is a subnav, we need the correpsonding HTMLElement for
     // .querySelector()
 
-    if (elem instanceof _NavItem__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+    if (elem instanceof _NavItem__WEBPACK_IMPORTED_MODULE_3__["default"]) {
       elem = elem.item;
     }
 
@@ -169,8 +171,13 @@ function () {
     this.items = [];
     var items = elem.querySelectorAll(elem.tagName + ' > ul > li');
     items.forEach(function (item) {
-      _this.items.push(new _NavItem__WEBPACK_IMPORTED_MODULE_2__["default"](item, _this));
-    });
+      _this.items.push(new _NavItem__WEBPACK_IMPORTED_MODULE_3__["default"](item, _this));
+    }); // add custom events to alert others when the mobile nav opens or closes
+
+    this.openEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_2__["createEvent"])('openNav'); // dispatched in this.openMobileNav()
+
+    this.closeEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_2__["createEvent"])('closeNav'); // dispatched in this.closeMobileNav()
+
     elem.addEventListener('keydown', this);
 
     if (this.toggle) {
@@ -194,7 +201,7 @@ function () {
     value: function getTopNav() {
       var nav = this;
 
-      while (nav.elem instanceof _NavItem__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+      while (nav.elem instanceof _NavItem__WEBPACK_IMPORTED_MODULE_3__["default"]) {
         // If nav is the main nav, nav.elem will be an HTMLElement
         // (the <nav> element).
         // If nav.elem is a NavItem, then this is a subNav, so get the Nav that
@@ -229,7 +236,7 @@ function () {
   }, {
     key: "isExpanded",
     value: function isExpanded() {
-      if (this.elem instanceof _NavItem__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+      if (this.elem instanceof _NavItem__WEBPACK_IMPORTED_MODULE_3__["default"]) {
         return this.elem.isExpanded();
       }
 
@@ -247,7 +254,7 @@ function () {
   }, {
     key: "setExpanded",
     value: function setExpanded(value) {
-      if (this.elem instanceof _NavItem__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+      if (this.elem instanceof _NavItem__WEBPACK_IMPORTED_MODULE_3__["default"]) {
         this.elem.setExpanded(value);
       } else {
         this.elem.setAttribute('aria-expanded', value);
@@ -419,7 +426,10 @@ function () {
 
       if (focusOnFirst) {
         this.focusOn('first'); // Focus on the first top level link
-      }
+      } // alert others the mobile nav has opened
+
+
+      this.elem.dispatchEvent(this.openEvent);
     }
     /**
      * Mark this mobile closed, and restore the button text to what it was
@@ -429,8 +439,12 @@ function () {
   }, {
     key: "closeMobileNav",
     value: function closeMobileNav() {
-      this.setExpanded('false');
-      this.toggle.innerText = this.toggleText;
+      if (this.isExpanded()) {
+        this.setExpanded('false');
+        this.toggle.innerText = this.toggleText; // alert others the mobile nav has closed
+
+        this.elem.dispatchEvent(this.closeEvent);
+      }
     } // -------------------------------------------------------------------------
     // Event handlers
     // -------------------------------------------------------------------------
@@ -546,6 +560,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _globals__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./globals */ "./core/src/js/components/main-nav/globals.js");
 /* harmony import */ var _utilities_keyboard__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../utilities/keyboard */ "./core/src/js/utilities/keyboard.js");
 /* harmony import */ var _Nav__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./Nav */ "./core/src/js/components/main-nav/Nav.js");
+/* harmony import */ var _utilities_events__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../../utilities/events */ "./core/src/js/utilities/events.js");
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
@@ -591,7 +606,11 @@ function () {
       this.subNav = new _Nav__WEBPACK_IMPORTED_MODULE_2__["default"](this); // Maintain global list of subnavs for closeAllSubNavs().
 
       _globals__WEBPACK_IMPORTED_MODULE_0__["theSubNavs"].push(this);
-      this.item.addEventListener('click', this);
+      this.item.addEventListener('click', this); // add custom events to alert others when a subnav opens or closes
+
+      this.openEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_3__["createEvent"])('openSubnav'); // dispatched in this.openSubNav()
+
+      this.closeEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_3__["createEvent"])('closeSubnav'); // dispatched in this.closeSubNav()
     }
   } // -------------------------------------------------------------------------
   // Helper Methods.
@@ -698,6 +717,8 @@ function () {
         if (focusOnFirst) {
           this.subNav.focusOn('first');
         }
+
+        this.item.dispatchEvent(this.openEvent);
       }
     }
     /**
@@ -716,11 +737,15 @@ function () {
       var focusOnTrigger = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
 
       if (this.isSubNavTrigger()) {
-        this.item.classList.remove('su-main-nav__item--expanded');
-        this.setExpanded('false');
+        if (this.isExpanded()) {
+          this.item.classList.remove('su-main-nav__item--expanded');
+          this.setExpanded('false');
 
-        if (focusOnTrigger) {
-          this.link.focus();
+          if (focusOnTrigger) {
+            this.link.focus();
+          }
+
+          this.item.dispatchEvent(this.closeEvent);
         }
       } else if (this.isSubNavItem()) {
         // This.nav.elem should be a subNavTrigger.
@@ -1023,6 +1048,38 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _scss_decanter_scss__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_scss_decanter_scss__WEBPACK_IMPORTED_MODULE_1__);
 
 
+
+/***/ }),
+
+/***/ "./core/src/js/utilities/events.js":
+/*!*****************************************!*\
+  !*** ./core/src/js/utilities/events.js ***!
+  \*****************************************/
+/*! exports provided: createEvent */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "createEvent", function() { return createEvent; });
+/**
+ * Create an event with the specified name in a browser-agnostic way.
+ * @param string eventName
+ * @return Event
+ */
+var createEvent = function createEvent() {
+  var eventName = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+  if (typeof eventName !== 'string' || eventName.length <= 0) return;
+
+  if (typeof Event == 'function') {
+    // modern browsers
+    return new Event(eventName);
+  } else {
+    // IE :(
+    var ev = document.createEvent('UIEvent');
+    ev.initEvent(eventName, true, true);
+    return ev;
+  }
+};
 
 /***/ }),
 

--- a/core/dist/js/decanter.js
+++ b/core/dist/js/decanter.js
@@ -1063,14 +1063,14 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "createEvent", function() { return createEvent; });
 /**
  * Create an event with the specified name in a browser-agnostic way.
- * @param {string} eventName
- * @return {Event}
+ * @param {string} eventName - the name of the event
+ * @return {Event} - instance of event which can be dispatched / listened for
  */
 var createEvent = function createEvent() {
   var eventName = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
 
   if (typeof eventName !== 'string' || eventName.length <= 0) {
-    return;
+    return null;
   }
 
   if (typeof Event == 'function') {

--- a/core/dist/js/decanter.js
+++ b/core/dist/js/decanter.js
@@ -168,16 +168,18 @@ function () {
 
     this.toggle = elem.querySelector(elem.tagName + ' > button');
     this.toggleText = this.toggle ? this.toggle.innerText : '';
-    this.items = [];
+    this.items = []; // Add custom events to alert others when the mobile nav
+    // opens or closes.
+    // this.openEvent is dispatched in this.openMobileNav().
+
+    this.openEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_2__["createEvent"])('openNav'); // this.closeEvent is dispatched in this.closeMobileNav().
+
+    this.closeEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_2__["createEvent"])('closeNav'); // Initialize items
+
     var items = elem.querySelectorAll(elem.tagName + ' > ul > li');
     items.forEach(function (item) {
       _this.items.push(new _NavItem__WEBPACK_IMPORTED_MODULE_3__["default"](item, _this));
-    }); // add custom events to alert others when the mobile nav opens or closes
-
-    this.openEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_2__["createEvent"])('openNav'); // dispatched in this.openMobileNav()
-
-    this.closeEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_2__["createEvent"])('closeNav'); // dispatched in this.closeMobileNav()
-
+    });
     elem.addEventListener('keydown', this);
 
     if (this.toggle) {
@@ -365,8 +367,8 @@ function () {
     key: "focusOn",
     value: function focusOn(link) {
       var currentItem = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-      var currentIndex = null;
-      var lastIndex = null;
+      var currentIndex = null,
+          lastIndex = null;
 
       if (currentItem) {
         currentIndex = this.items.indexOf(currentItem);
@@ -425,8 +427,9 @@ function () {
       this.toggle.innerText = 'Close';
 
       if (focusOnFirst) {
-        this.focusOn('first'); // Focus on the first top level link
-      } // alert others the mobile nav has opened
+        // Focus on the first top level link.
+        this.focusOn('first');
+      } // Alert others the mobile nav has opened.
 
 
       this.elem.dispatchEvent(this.openEvent);
@@ -441,7 +444,7 @@ function () {
     value: function closeMobileNav() {
       if (this.isExpanded()) {
         this.setExpanded('false');
-        this.toggle.innerText = this.toggleText; // alert others the mobile nav has closed
+        this.toggle.innerText = this.toggleText; // Alert others the mobile nav has closed.
 
         this.elem.dispatchEvent(this.closeEvent);
       }
@@ -603,14 +606,15 @@ function () {
     this.item.addEventListener('keydown', this);
 
     if (this.isSubNavTrigger()) {
-      this.subNav = new _Nav__WEBPACK_IMPORTED_MODULE_2__["default"](this); // Maintain global list of subnavs for closeAllSubNavs().
+      this.subNav = new _Nav__WEBPACK_IMPORTED_MODULE_2__["default"](this); // Add custom events to alert others when a subnav opens or closes.
+      // this.openEvent is dispatched in this.openSubNav().
+
+      this.openEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_3__["createEvent"])('openSubnav'); // this.closeEvent is dispatched in this.closeSubNav().
+
+      this.closeEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_3__["createEvent"])('closeSubnav'); // Maintain global list of subnavs for closeAllSubNavs().
 
       _globals__WEBPACK_IMPORTED_MODULE_0__["theSubNavs"].push(this);
-      this.item.addEventListener('click', this); // add custom events to alert others when a subnav opens or closes
-
-      this.openEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_3__["createEvent"])('openSubnav'); // dispatched in this.openSubNav()
-
-      this.closeEvent = Object(_utilities_events__WEBPACK_IMPORTED_MODULE_3__["createEvent"])('closeSubnav'); // dispatched in this.closeSubNav()
+      this.item.addEventListener('click', this);
     }
   } // -------------------------------------------------------------------------
   // Helper Methods.
@@ -994,13 +998,13 @@ document.addEventListener('DOMContentLoaded', function (event) {
 
   var firstZindex;
   navs.forEach(function (nav, index) {
-    // remove the class that formats the nav for browsers with javascript disabled
-    nav.classList.remove('no-js'); // create an instance of Nav, which in turn creates appropriate instances of NavItem
+    // Remove the class that formats the nav for browsers with javascript disabled.
+    nav.classList.remove('no-js'); // Create an instance of Nav, which in turn creates appropriate instances of NavItem.
 
-    var theNav = new _Nav__WEBPACK_IMPORTED_MODULE_2__["default"](nav); // remember the nav for closeAllMobileNavs()
+    var theNav = new _Nav__WEBPACK_IMPORTED_MODULE_2__["default"](nav); // Remember the nav for closeAllMobileNavs().
 
-    _globals__WEBPACK_IMPORTED_MODULE_1__["theNavs"].push(theNav); // manage zindexes in case there are multiple navs near enough for subnavs to overlap
-    // extremely unlikely, but it happens in the styleguide
+    _globals__WEBPACK_IMPORTED_MODULE_1__["theNavs"].push(theNav); // Manage zindexes in case there are multiple navs near enough for subnavs to overlap.
+    // Rare, but it happens in the styleguide.
 
     if (index === 0) {
       firstZindex = getComputedStyle(nav, null).zIndex;
@@ -1070,17 +1074,17 @@ __webpack_require__.r(__webpack_exports__);
 var createEvent = function createEvent(eventName) {
   if (typeof eventName !== 'string' || eventName.length <= 0) {
     return null;
-  }
+  } // Modern browsers.
+
 
   if (typeof Event == 'function') {
-    // modern browsers
     return new Event(eventName);
-  } else {
-    // IE :(
-    var ev = document.createEvent('UIEvent');
-    ev.initEvent(eventName, true, true);
-    return ev;
-  }
+  } // IE.
+  else {
+      var ev = document.createEvent('UIEvent');
+      ev.initEvent(eventName, true, true);
+      return ev;
+    }
 };
 
 /***/ }),

--- a/core/dist/js/decanter.js
+++ b/core/dist/js/decanter.js
@@ -1063,12 +1063,15 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "createEvent", function() { return createEvent; });
 /**
  * Create an event with the specified name in a browser-agnostic way.
- * @param string eventName
- * @return Event
+ * @param {string} eventName
+ * @return {Event}
  */
 var createEvent = function createEvent() {
   var eventName = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
-  if (typeof eventName !== 'string' || eventName.length <= 0) return;
+
+  if (typeof eventName !== 'string' || eventName.length <= 0) {
+    return;
+  }
 
   if (typeof Event == 'function') {
     // modern browsers

--- a/core/dist/js/decanter.js
+++ b/core/dist/js/decanter.js
@@ -988,18 +988,19 @@ __webpack_require__.r(__webpack_exports__);
 
 document.addEventListener('DOMContentLoaded', function (event) {
   // The css class that this following behaviour is applied to.
-  var navClass = 'su-main-nav'; // Variables.
-  // All main navs.
+  var navClass = 'su-main-nav'; // All main navs.
 
-  var navs = document.querySelectorAll('.' + navClass); // ---------------------------------------------------------------------------
-  // Execution Code.
-  // ---------------------------------------------------------------------------
-  // Process each nav.
+  var navs = document.querySelectorAll('.' + navClass); // Process each nav.
 
   var firstZindex;
   navs.forEach(function (nav, index) {
-    var theNav = new _Nav__WEBPACK_IMPORTED_MODULE_2__["default"](nav);
-    _globals__WEBPACK_IMPORTED_MODULE_1__["theNavs"].push(theNav);
+    // remove the class that formats the nav for browsers with javascript disabled
+    nav.classList.remove('no-js'); // create an instance of Nav, which in turn creates appropriate instances of NavItem
+
+    var theNav = new _Nav__WEBPACK_IMPORTED_MODULE_2__["default"](nav); // remember the nav for closeAllMobileNavs()
+
+    _globals__WEBPACK_IMPORTED_MODULE_1__["theNavs"].push(theNav); // manage zindexes in case there are multiple navs near enough for subnavs to overlap
+    // extremely unlikely, but it happens in the styleguide
 
     if (index === 0) {
       firstZindex = getComputedStyle(nav, null).zIndex;

--- a/core/dist/js/decanter.js
+++ b/core/dist/js/decanter.js
@@ -1067,9 +1067,7 @@ __webpack_require__.r(__webpack_exports__);
  * @param {string} eventName - the name of the event
  * @return {Event} - instance of event which can be dispatched / listened for
  */
-var createEvent = function createEvent() {
-  var eventName = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
-
+var createEvent = function createEvent(eventName) {
   if (typeof eventName !== 'string' || eventName.length <= 0) {
     return null;
   }

--- a/core/src/js/components/main-nav/Nav.js
+++ b/core/src/js/components/main-nav/Nav.js
@@ -49,8 +49,8 @@ export default class Nav {
     );
 
     // add custom events to alert others when the mobile nav opens or closes
-    this.openEvent = createEvent( 'openNav' ); // dispatched in this.openMobileNav()
-    this.closeEvent = createEvent( 'closeNav' ); // dispatched in this.closeMobileNav()
+    this.openEvent = createEvent('openNav'); // dispatched in this.openMobileNav()
+    this.closeEvent = createEvent('closeNav'); // dispatched in this.closeMobileNav()
 
     elem.addEventListener('keydown', this);
 
@@ -280,7 +280,7 @@ export default class Nav {
    */
   closeMobileNav() {
     if (this.isExpanded()) {
-      this.setExpanded( 'false' );
+      this.setExpanded('false');
       this.toggle.innerText = this.toggleText;
       // alert others the mobile nav has closed
       this.elem.dispatchEvent(this.closeEvent);

--- a/core/src/js/components/main-nav/Nav.js
+++ b/core/src/js/components/main-nav/Nav.js
@@ -41,16 +41,20 @@ export default class Nav {
     this.toggle = elem.querySelector(elem.tagName + ' > button');
     this.toggleText = this.toggle ? this.toggle.innerText : '';
     this.items = [];
+    // Add custom events to alert others when the mobile nav
+    // opens or closes.
+    // this.openEvent is dispatched in this.openMobileNav().
+    this.openEvent = createEvent('openNav');
+    // this.closeEvent is dispatched in this.closeMobileNav().
+    this.closeEvent = createEvent('closeNav');
+
+    // Initialize items
     let items = elem.querySelectorAll(elem.tagName + ' > ul > li');
     items.forEach(
       item => {
         this.items.push(new NavItem(item, this));
       }
     );
-
-    // add custom events to alert others when the mobile nav opens or closes
-    this.openEvent = createEvent('openNav'); // dispatched in this.openMobileNav()
-    this.closeEvent = createEvent('closeNav'); // dispatched in this.closeMobileNav()
 
     elem.addEventListener('keydown', this);
 
@@ -214,8 +218,8 @@ export default class Nav {
    *                                relative to.
    */
   focusOn(link, currentItem = null) {
-    var currentIndex = null;
-    var lastIndex = null;
+    let currentIndex = null,
+      lastIndex = null;
     if (currentItem) {
       currentIndex = this.items.indexOf(currentItem);
       lastIndex = this.items.length - 1;
@@ -268,9 +272,10 @@ export default class Nav {
     this.setExpanded('true');
     this.toggle.innerText = 'Close';
     if (focusOnFirst) {
-      this.focusOn('first'); // Focus on the first top level link
+      // Focus on the first top level link.
+      this.focusOn('first');
     }
-    // alert others the mobile nav has opened
+    // Alert others the mobile nav has opened.
     this.elem.dispatchEvent(this.openEvent);
   }
 
@@ -282,7 +287,7 @@ export default class Nav {
     if (this.isExpanded()) {
       this.setExpanded('false');
       this.toggle.innerText = this.toggleText;
-      // alert others the mobile nav has closed
+      // Alert others the mobile nav has closed.
       this.elem.dispatchEvent(this.closeEvent);
     }
   }

--- a/core/src/js/components/main-nav/Nav.js
+++ b/core/src/js/components/main-nav/Nav.js
@@ -218,8 +218,8 @@ export default class Nav {
    *                                relative to.
    */
   focusOn(link, currentItem = null) {
-    let currentIndex = null,
-      lastIndex = null;
+    let currentIndex = null;
+    let lastIndex = null;
     if (currentItem) {
       currentIndex = this.items.indexOf(currentItem);
       lastIndex = this.items.length - 1;

--- a/core/src/js/components/main-nav/Nav.js
+++ b/core/src/js/components/main-nav/Nav.js
@@ -1,5 +1,6 @@
 import { closeAllMobileNavs } from './globals';
 import { isEsc, isSpace, isEnter } from "../../utilities/keyboard";
+import { createEvent } from '../../utilities/events';
 import NavItem from './NavItem';
 
 /**
@@ -46,6 +47,10 @@ export default class Nav {
         this.items.push(new NavItem(item, this));
       }
     );
+
+    // add custom events to alert others when the mobile nav opens or closes
+    this.openEvent = createEvent( 'openNav' ); // dispatched in this.openMobileNav()
+    this.closeEvent = createEvent( 'closeNav' ); // dispatched in this.closeMobileNav()
 
     elem.addEventListener('keydown', this);
 
@@ -265,6 +270,8 @@ export default class Nav {
     if (focusOnFirst) {
       this.focusOn('first'); // Focus on the first top level link
     }
+    // alert others the mobile nav has opened
+    this.elem.dispatchEvent(this.openEvent);
   }
 
   /**
@@ -272,8 +279,12 @@ export default class Nav {
    * initially.
    */
   closeMobileNav() {
-    this.setExpanded('false');
-    this.toggle.innerText = this.toggleText;
+    if (this.isExpanded()) {
+      this.setExpanded( 'false' );
+      this.toggle.innerText = this.toggleText;
+      // alert others the mobile nav has closed
+      this.elem.dispatchEvent(this.closeEvent);
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/core/src/js/components/main-nav/NavItem.js
+++ b/core/src/js/components/main-nav/NavItem.js
@@ -32,13 +32,15 @@ export default class NavItem {
 
     if (this.isSubNavTrigger()) {
       this.subNav = new Nav(this);
+      // Add custom events to alert others when a subnav opens or closes.
+      // this.openEvent is dispatched in this.openSubNav().
+      this.openEvent = createEvent('openSubnav');
+      // this.closeEvent is dispatched in this.closeSubNav().
+      this.closeEvent = createEvent('closeSubnav');
+
       // Maintain global list of subnavs for closeAllSubNavs().
       theSubNavs.push(this);
       this.item.addEventListener('click', this);
-
-      // add custom events to alert others when a subnav opens or closes
-      this.openEvent = createEvent('openSubnav'); // dispatched in this.openSubNav()
-      this.closeEvent = createEvent('closeSubnav'); // dispatched in this.closeSubNav()
     }
   }
 

--- a/core/src/js/components/main-nav/NavItem.js
+++ b/core/src/js/components/main-nav/NavItem.js
@@ -1,7 +1,7 @@
-import { theSubNavs, closeAllSubNavs } from './globals';
-import { isHome, isEnd, isTab, isSpace, isEnter, isLeftArrow, isRightArrow, isUpArrow, isDownArrow } from "../../utilities/keyboard";
+import {theSubNavs, closeAllSubNavs} from './globals';
+import {isHome, isEnd, isTab, isSpace, isEnter, isLeftArrow, isRightArrow, isUpArrow, isDownArrow} from "../../utilities/keyboard";
 import Nav from './Nav';
-import { createEvent } from '../../utilities/events';
+import {createEvent} from '../../utilities/events';
 
 /**
  * Represent an item in a navigation menu. May be a direct link or a subnav
@@ -37,8 +37,8 @@ export default class NavItem {
       this.item.addEventListener('click', this);
 
       // add custom events to alert others when a subnav opens or closes
-      this.openEvent = createEvent( 'openSubnav' ); // dispatched in this.openSubNav()
-      this.closeEvent = createEvent( 'closeSubnav' ); // dispatched in this.closeSubNav()
+      this.openEvent = createEvent('openSubnav'); // dispatched in this.openSubNav()
+      this.closeEvent = createEvent('closeSubnav'); // dispatched in this.closeSubNav()
     }
   }
 
@@ -130,7 +130,7 @@ export default class NavItem {
       if (focusOnFirst) {
         this.subNav.focusOn('first');
       }
-      this.item.dispatchEvent( this.openEvent );
+      this.item.dispatchEvent(this.openEvent);
     }
   }
 
@@ -146,12 +146,12 @@ export default class NavItem {
   closeSubNav(focusOnTrigger = false) {
     if (this.isSubNavTrigger()) {
       if (this.isExpanded()) {
-        this.item.classList.remove( 'su-main-nav__item--expanded' );
-        this.setExpanded( 'false' );
-        if ( focusOnTrigger ) {
+        this.item.classList.remove('su-main-nav__item--expanded');
+        this.setExpanded('false');
+        if (focusOnTrigger) {
           this.link.focus();
         }
-        this.item.dispatchEvent( this.closeEvent );
+        this.item.dispatchEvent(this.closeEvent);
       }
     }
     else if (this.isSubNavItem()) {

--- a/core/src/js/components/main-nav/NavItem.js
+++ b/core/src/js/components/main-nav/NavItem.js
@@ -1,7 +1,7 @@
 import { theSubNavs, closeAllSubNavs } from './globals';
 import { isHome, isEnd, isTab, isSpace, isEnter, isLeftArrow, isRightArrow, isUpArrow, isDownArrow } from "../../utilities/keyboard";
 import Nav from './Nav';
-import '../../utilities/keyboard';
+import { createEvent } from '../../utilities/events';
 
 /**
  * Represent an item in a navigation menu. May be a direct link or a subnav
@@ -35,6 +35,10 @@ export default class NavItem {
       // Maintain global list of subnavs for closeAllSubNavs().
       theSubNavs.push(this);
       this.item.addEventListener('click', this);
+
+      // add custom events to alert others when a subnav opens or closes
+      this.openEvent = createEvent( 'openSubnav' ); // dispatched in this.openSubNav()
+      this.closeEvent = createEvent( 'closeSubnav' ); // dispatched in this.closeSubNav()
     }
   }
 
@@ -126,6 +130,7 @@ export default class NavItem {
       if (focusOnFirst) {
         this.subNav.focusOn('first');
       }
+      this.item.dispatchEvent( this.openEvent );
     }
   }
 
@@ -140,10 +145,13 @@ export default class NavItem {
    */
   closeSubNav(focusOnTrigger = false) {
     if (this.isSubNavTrigger()) {
-      this.item.classList.remove('su-main-nav__item--expanded');
-      this.setExpanded('false');
-      if (focusOnTrigger) {
-        this.link.focus();
+      if (this.isExpanded()) {
+        this.item.classList.remove( 'su-main-nav__item--expanded' );
+        this.setExpanded( 'false' );
+        if ( focusOnTrigger ) {
+          this.link.focus();
+        }
+        this.item.dispatchEvent( this.closeEvent );
       }
     }
     else if (this.isSubNavItem()) {

--- a/core/src/js/components/main-nav/main-nav.js
+++ b/core/src/js/components/main-nav/main-nav.js
@@ -12,17 +12,17 @@ document.addEventListener('DOMContentLoaded', event => {
   // Process each nav.
   let firstZindex;
   navs.forEach((nav, index) => {
-    // remove the class that formats the nav for browsers with javascript disabled
+    // Remove the class that formats the nav for browsers with javascript disabled.
     nav.classList.remove('no-js');
 
-    // create an instance of Nav, which in turn creates appropriate instances of NavItem
+    // Create an instance of Nav, which in turn creates appropriate instances of NavItem.
     const theNav = new Nav(nav);
 
-    // remember the nav for closeAllMobileNavs()
+    // Remember the nav for closeAllMobileNavs().
     theNavs.push(theNav);
 
-    // manage zindexes in case there are multiple navs near enough for subnavs to overlap
-    // extremely unlikely, but it happens in the styleguide
+    // Manage zindexes in case there are multiple navs near enough for subnavs to overlap.
+    // Rare, but it happens in the styleguide.
     if (index === 0) {
       firstZindex = getComputedStyle(nav, null).zIndex;
     }

--- a/core/src/js/components/main-nav/main-nav.js
+++ b/core/src/js/components/main-nav/main-nav.js
@@ -6,22 +6,23 @@ document.addEventListener('DOMContentLoaded', event => {
 
   // The css class that this following behaviour is applied to.
   const navClass = 'su-main-nav';
-
-  // Variables.
-
   // All main navs.
   const navs = document.querySelectorAll('.' + navClass);
-
-  // ---------------------------------------------------------------------------
-  // Execution Code.
-  // ---------------------------------------------------------------------------
 
   // Process each nav.
   let firstZindex;
   navs.forEach((nav, index) => {
+    // remove the class that formats the nav for browsers with javascript disabled
+    nav.classList.remove('no-js');
+
+    // create an instance of Nav, which in turn creates appropriate instances of NavItem
     const theNav = new Nav(nav);
+
+    // remember the nav for closeAllMobileNavs()
     theNavs.push(theNav);
 
+    // manage zindexes in case there are multiple navs near enough for subnavs to overlap
+    // extremely unlikely, but it happens in the styleguide
     if (index === 0) {
       firstZindex = getComputedStyle(nav, null).zIndex;
     }

--- a/core/src/js/utilities/events.js
+++ b/core/src/js/utilities/events.js
@@ -1,16 +1,18 @@
 /**
  * Create an event with the specified name in a browser-agnostic way.
- * @param string eventName
- * @return Event
+ * @param {string} eventName
+ * @return {Event}
  */
-export const createEvent = ( eventName = '' ) => {
-  if ( typeof eventName !== 'string' || eventName.length <= 0 ) return;
-  if ( typeof Event == 'function' ) { // modern browsers
-    return new Event( eventName );
+export const createEvent = (eventName = '') => {
+  if (typeof eventName !== 'string' || eventName.length <= 0) {
+    return;
+  }
+  if (typeof Event == 'function') { // modern browsers
+    return new Event(eventName);
   }
   else { // IE :(
-    let ev = document.createEvent( 'UIEvent' );
-    ev.initEvent( eventName, true, true );
+    let ev = document.createEvent('UIEvent');
+    ev.initEvent(eventName, true, true);
     return ev;
   }
-}
+};

--- a/core/src/js/utilities/events.js
+++ b/core/src/js/utilities/events.js
@@ -1,0 +1,16 @@
+/**
+ * Create an event with the specified name in a browser-agnostic way.
+ * @param string eventName
+ * @return Event
+ */
+export const createEvent = ( eventName = '' ) => {
+  if ( typeof eventName !== 'string' || eventName.length <= 0 ) return;
+  if ( typeof Event == 'function' ) { // modern browsers
+    return new Event( eventName );
+  }
+  else { // IE :(
+    let ev = document.createEvent( 'UIEvent' );
+    ev.initEvent( eventName, true, true );
+    return ev;
+  }
+}

--- a/core/src/js/utilities/events.js
+++ b/core/src/js/utilities/events.js
@@ -7,10 +7,12 @@ export const createEvent = (eventName) => {
   if (typeof eventName !== 'string' || eventName.length <= 0) {
     return null;
   }
-  if (typeof Event == 'function') { // modern browsers
+  // Modern browsers
+  if (typeof Event == 'function') {
     return new Event(eventName);
   }
-  else { // IE :(
+  // IE
+  else {
     let ev = document.createEvent('UIEvent');
     ev.initEvent(eventName, true, true);
     return ev;

--- a/core/src/js/utilities/events.js
+++ b/core/src/js/utilities/events.js
@@ -3,7 +3,7 @@
  * @param {string} eventName - the name of the event
  * @return {Event} - instance of event which can be dispatched / listened for
  */
-export const createEvent = (eventName = '') => {
+export const createEvent = (eventName) => {
   if (typeof eventName !== 'string' || eventName.length <= 0) {
     return null;
   }

--- a/core/src/js/utilities/events.js
+++ b/core/src/js/utilities/events.js
@@ -1,11 +1,11 @@
 /**
  * Create an event with the specified name in a browser-agnostic way.
- * @param {string} eventName
- * @return {Event}
+ * @param {string} eventName - the name of the event
+ * @return {Event} - instance of event which can be dispatched / listened for
  */
 export const createEvent = (eventName = '') => {
   if (typeof eventName !== 'string' || eventName.length <= 0) {
-    return;
+    return null;
   }
   if (typeof Event == 'function') { // modern browsers
     return new Event(eventName);

--- a/core/src/scss/components/main-nav/_main-nav.scss
+++ b/core/src/scss/components/main-nav/_main-nav.scss
@@ -9,11 +9,13 @@
 // The following Javascript events are dispatched:
 // - `openNav` - fires when a mobile nav is opened - dispatched on `.su-main-nav`
 // - `closeNav` - fires when a mobile nav is closed - dispatched on `.su-main-nav`
-// - `openSubnav` - fires when a subnav is opened - dispatched on `.su-main-nav > ul > li`
-// - `closeSubnav` - fires when a subnav is closed - dispatched on `.su-main-nav > ul > li`
+// - `openSubnav` - fires when a subnav is opened - dispatched on `li.su-main-nav__item--parent`
+// - `closeSubnav` - fires when a subnav is closed - dispatched on `li.su-main-nav__item--parent`
 //
-// This component is implemented to be accessible. For more information, please see:
-// <a href="https://github.com/SU-SWS/decanter/wiki/About-the-Main-Nav-Component">https://github.com/SU-SWS/decanter/wiki/About-the-Main-Nav-Component</a>
+// The Main Navigation component is implemented to be accessible. For more information on building
+// accessible site navigation, please see
+// <a href="https://github.com/SU-SWS/decanter/wiki/About-the-Main-Nav-Component">About the Main Nav Component</a>
+// on Decanter's wiki.
 //
 //**Modifier classes for the Main Nav:**
 // - .su-main-nav--light          - Light colored theme

--- a/core/src/scss/components/main-nav/_main-nav.scss
+++ b/core/src/scss/components/main-nav/_main-nav.scss
@@ -6,8 +6,13 @@
 // It is a horizontal menu bar on larger breakpoints, while on smaller breakpoints,
 // it changes into a vertical menu and can be expanded or collapsed by a toggle button.
 //
-// This component is implemented to be accessible. For more information, please see:
+// The following Javascript events are dispatched:
+// - `openNav` - fires when a mobile nav is opened - dispatched on `.su-main-nav`
+// - `closeNav` - fires when a mobile nav is closed - dispatched on `.su-main-nav`
+// - `openSubnav` - fires when a subnav is opened - dispatched on `.su-main-nav > ul > li`
+// - `closeSubnav` - fires when a subnav is closed - dispatched on `.su-main-nav > ul > li`
 //
+// This component is implemented to be accessible. For more information, please see:
 // <a href="https://github.com/SU-SWS/decanter/wiki/About-the-Main-Nav-Component">https://github.com/SU-SWS/decanter/wiki/About-the-Main-Nav-Component</a>
 //
 //**Modifier classes for the Main Nav:**

--- a/core/src/templates/components/main-nav/main-nav.twig
+++ b/core/src/templates/components/main-nav/main-nav.twig
@@ -65,8 +65,3 @@
     %}
   {% endif %}
 </nav>
-<script>
-  // Do this immediately to minimize FOUC.
-  NodeList.prototype.forEach = NodeList.prototype.forEach || Array.prototype.forEach;
-  document.querySelectorAll('nav.su-main-nav').forEach(nav => { nav.classList.remove('no-js'); } );
-</script>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
In Scott's [event calendar project](http://events-dev.stanford.edu/), the **By Date** subnav contains a date picker. For accessibility reasons, he needs to place the focus on the date picker element when that subnav is opened. The cleanest way for him to do that is to add an event listener that responds whenever the appropriate subnav opens. He therefore needs an event to be triggered when a subnav opens. It seemed like it might also be useful to trigger events when a subnav closes, and when a mobile nav opens or closes.

# Needed By (Date)
Soon-ish, so Scott can respond to his accessibility issue.

# Urgency
Meh.

# Steps to Test

1. Pull the branch
1. `npm run build`
1. `npm run styleguide`
1. Visit your local dev instance in your browser and scroll down to the [Main Navigation](http://decanter.local/section-components.html#kssref-components-main-navigation) component
1. Open your console and paste the following commands
```
navs = document.querySelectorAll('.su-main-nav');
navs[1].addEventListener('openNav', (ev) => {console.log('mobile nav 1 OPENED');});
navs[1].addEventListener('closeNav', (ev) => {console.log('mobile nav 1 CLOSED');});
subnavs = document.querySelectorAll('.su-main-nav__item--parent');
subnavs[4].addEventListener('openSubnav', (ev) => {console.log('subnav 4 OPENED');});
subnavs[4].addEventListener('closeSubnav', (ev) => {console.log('subnav 4 CLOSED');});
subnavs[5].addEventListener('openSubnav', (ev) => {console.log('subnav 5 OPENED');});
subnavs[5].addEventListener('closeSubnav', (ev) => {console.log('subnav 5 CLOSED');});
```
6. With your console still open, try various ways of opening and closing  the **Useful Websites** and **Tools & Documentation** subnavs in the first example nav (**Default styling**). Notice the messages in the console.
6. Make your browser small enough so the example navs switch to mobile. With your console still open, try various ways of opening and closing  the first example nav (**Default styling**). Notice the messages in the console.

# Affected Projects or Products
None. However, we need to figure out how Scott can get these changes. Right now he's fetching the `5.0.0` tag in the decanter repo to keep his environment stable. He probably shouldn't be pointing directly to `master`, as that's still volatile. Should we create a `5.0.1` tag? Or should we keep this branch alive after it's merged and have him point to this branch?

# Associated Issues and/or People
- @stocker

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)