### PR TITLE
Fix main nav color variants and work with new linting rules

### DIFF
--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -8476,144 +8476,144 @@ a {
   margin-left: auto; }
 
 @media (max-width: 991px) {
-  .su-main-nav--dark .su-main-nav__toggle {
+  .su-main-nav.su-main-nav--dark .su-main-nav__toggle {
     color: #ffffff; }
-    .su-main-nav--dark .su-main-nav__toggle:hover::before, .su-main-nav--dark .su-main-nav__toggle:focus::before {
+    .su-main-nav.su-main-nav--dark .su-main-nav__toggle:hover::before, .su-main-nav.su-main-nav--dark .su-main-nav__toggle:focus::before {
       background-color: #ffffff; }
-    .su-main-nav--dark .su-main-nav__toggle:active::before {
+    .su-main-nav.su-main-nav--dark .su-main-nav__toggle:active::before {
       background-color: #ec0513; }
-    .su-main-nav--dark .su-main-nav__toggle::after {
+    .su-main-nav.su-main-nav--dark .su-main-nav__toggle::after {
       background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTAgNC4xMzU3NUMwIDMuMjMyMDEgMC43MzI2MjUgMi40OTkzOSAxLjYzNjM2IDIuNDk5MzlIMjIuMzYzNkMyMy4yNjc0IDIuNDk5MzkgMjQgMy4yMzIwMSAyNCA0LjEzNTc1QzI0IDUuMDM5NDkgMjMuMjY3NCA1Ljc3MjEyIDIyLjM2MzYgNS43NzIxMkgxLjYzNjM2QzAuNzMyNjI1IDUuNzcyMTIgMCA1LjAzOTQ5IDAgNC4xMzU3NVoiIGZpbGw9IiNmZmZmZmYiLz4KPHBhdGggZD0iTTAgMTkuNDA4NUMwIDE4LjUwNDcgMC43MzI2MjUgMTcuNzcyMSAxLjYzNjM2IDE3Ljc3MjFIMjIuMzYzNkMyMy4yNjc0IDE3Ljc3MjEgMjQgMTguNTA0NyAyNCAxOS40MDg1QzI0IDIwLjMxMjIgMjMuMjY3NCAyMS4wNDQ4IDIyLjM2MzYgMjEuMDQ0OEgxLjYzNjM2QzAuNzMyNjI1IDIxLjA0NDggMCAyMC4zMTIyIDAgMTkuNDA4NVoiIGZpbGw9IiNmZmZmZmYiLz4KPHBhdGggZD0iTTAgMTEuNzcyMUMwIDEwLjg2ODQgMC43MzI2MjUgMTAuMTM1NyAxLjYzNjM2IDEwLjEzNTdIMjIuMzYzNkMyMy4yNjc0IDEwLjEzNTcgMjQgMTAuODY4NCAyNCAxMS43NzIxQzI0IDEyLjY3NTggMjMuMjY3NCAxMy40MDg1IDIyLjM2MzYgMTMuNDA4NUgxLjYzNjM2QzAuNzMyNjI1IDEzLjQwODUgMCAxMi42NzU4IDAgMTEuNzcyMVoiIGZpbGw9IiNmZmZmZmYiLz4KPC9zdmc+Cg==) no-repeat 3px 0; }
-    .su-main-nav--dark .su-main-nav__toggle[aria-expanded="true"]::before {
+    .su-main-nav.su-main-nav--dark .su-main-nav__toggle[aria-expanded="true"]::before {
       background-color: #ffffff; }
-    .su-main-nav--dark .su-main-nav__toggle[aria-expanded="true"]::after {
+    .su-main-nav.su-main-nav--dark .su-main-nav__toggle[aria-expanded="true"]::after {
       background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjx0aXRsZT5jbG9zZS1ibGFjazwvdGl0bGU+PHBhdGggZD0iTTEwLjU2LDEyLC4zMiwyMi4yMWExLDEsMCwwLDAsMS40MSwxLjQxTDEyLDEzLjM5LDIyLjIxLDIzLjYyYTEsMSwwLDAsMCwxLjQxLTEuNDFMMTMuMzksMTIsMjMuNjIsMS43NGExLDEsMCwwLDAsMC0xLjQyLDEsMSwwLDAsMC0xLjQxLDBMMTIsMTAuNTYsMS43NC4zMkExLDEsMCwwLDAsLjMyLDEuNzRaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMC4wMyAtMC4wMykiIGZpbGw9IiNmZmZmZmYiIC8+PC9zdmc+) no-repeat 3px 0;
       background-size: 16px 16px; }
-    .su-main-nav--dark .su-main-nav__toggle[aria-expanded="true"]:hover::before {
+    .su-main-nav.su-main-nav--dark .su-main-nav__toggle[aria-expanded="true"]:hover::before {
       background-color: #ec0513; } }
 
 @media only screen and (min-width: 992px) {
-  .su-main-nav--dark > ul > li > a {
+  .su-main-nav.su-main-nav--dark > ul > li > a {
     color: #ffffff; }
-    .su-main-nav--dark > ul > li > a:hover, .su-main-nav--dark > ul > li > a:focus {
+    .su-main-nav.su-main-nav--dark > ul > li > a:hover, .su-main-nav.su-main-nav--dark > ul > li > a:focus {
       color: #ffffff; }
-      .su-main-nav--dark > ul > li > a:hover::before, .su-main-nav--dark > ul > li > a:focus::before {
+      .su-main-nav.su-main-nav--dark > ul > li > a:hover::before, .su-main-nav.su-main-nav--dark > ul > li > a:focus::before {
         background-color: #ffffff; }
-    .su-main-nav--dark > ul > li > a:active {
+    .su-main-nav.su-main-nav--dark > ul > li > a:active {
       color: #ffffff; }
-      .su-main-nav--dark > ul > li > a:active::before {
+      .su-main-nav.su-main-nav--dark > ul > li > a:active::before {
         background-color: #ffffff; }
-    .su-main-nav--dark > ul > li > a[aria-expanded="true"] {
+    .su-main-nav.su-main-nav--dark > ul > li > a[aria-expanded="true"] {
       color: #ffffff; }
-      .su-main-nav--dark > ul > li > a[aria-expanded="true"]::before {
+      .su-main-nav.su-main-nav--dark > ul > li > a[aria-expanded="true"]::before {
         background-color: #ffffff; }
-      .su-main-nav--dark > ul > li > a[aria-expanded="true"]:hover {
+      .su-main-nav.su-main-nav--dark > ul > li > a[aria-expanded="true"]:hover {
         color: #ffffff; }
-        .su-main-nav--dark > ul > li > a[aria-expanded="true"]:hover::before {
+        .su-main-nav.su-main-nav--dark > ul > li > a[aria-expanded="true"]:hover::before {
           background-color: #ec0513; }
-  .su-main-nav--dark > ul > li.su-main-nav__item--parent > a::after {
+  .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--parent > a::after {
     background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMy40ODg3IDUuNDE1NjZDMjQuMTM2MyA2LjAwMDI0IDI0LjE3MzcgNi45ODQ0OSAyMy41NzI1IDcuNjE0MDRMMTMuMTcyNSAxOC41MDI5QzEyLjg2OTcgMTguODE5OSAxMi40NDQ5IDE5IDEyIDE5QzExLjU1NTEgMTkgMTEuMTMwMyAxOC44MTk5IDEwLjgyNzUgMTguNTAyOUwwLjQyNzUzOCA3LjYxNDA0Qy0wLjE3Mzc0NiA2Ljk4NDQ5IC0wLjEzNjI1MSA2LjAwMDI0IDAuNTExMjg2IDUuNDE1NjZDMS4xNTg4MiA0LjgzMTA4IDIuMTcxMTkgNC44Njc1MyAyLjc3MjQ4IDUuNDk3MDhMMTIgMTUuMTU4NEwyMS4yMjc1IDUuNDk3MDhDMjEuODI4OCA0Ljg2NzUzIDIyLjg0MTIgNC44MzEwOCAyMy40ODg3IDUuNDE1NjZaIiBmaWxsPSIjZmZmZmZmIi8+Cjwvc3ZnPgo=) no-repeat 0 0;
     background-size: 100%; }
-  .su-main-nav--dark > ul > li.su-main-nav__item--current > a {
+  .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--current > a {
     color: #ffffff; }
-    .su-main-nav--dark > ul > li.su-main-nav__item--current > a::before {
+    .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--current > a::before {
       background-color: #ec0513; }
-    .su-main-nav--dark > ul > li.su-main-nav__item--current > a:hover, .su-main-nav--dark > ul > li.su-main-nav__item--current > a:focus {
+    .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--current > a:hover, .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--current > a:focus {
       color: #ffffff; }
-      .su-main-nav--dark > ul > li.su-main-nav__item--current > a:hover::before, .su-main-nav--dark > ul > li.su-main-nav__item--current > a:focus::before {
+      .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--current > a:hover::before, .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--current > a:focus::before {
         background-color: #ffffff; }
-  .su-main-nav--dark > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a:focus {
+  .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a:focus {
     color: #ffffff; }
-    .su-main-nav--dark > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a:focus::before {
+    .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a:focus::before {
       background-color: #ffffff; }
-  .su-main-nav--dark > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a[aria-expanded="true"]:hover {
+  .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a[aria-expanded="true"]:hover {
     color: #ffffff; }
-    .su-main-nav--dark > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a[aria-expanded="true"]:hover::before {
+    .su-main-nav.su-main-nav--dark > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a[aria-expanded="true"]:hover::before {
       background-color: #ec0513; } }
 
-.su-main-nav--light .su-main-nav__toggle[aria-expanded="true"]::before {
+.su-main-nav.su-main-nav--light .su-main-nav__toggle[aria-expanded="true"]::before {
   background-color: #b6b1a9; }
 
-.su-main-nav--light .su-main-nav__toggle[aria-expanded="true"]:hover::before {
+.su-main-nav.su-main-nav--light .su-main-nav__toggle[aria-expanded="true"]:hover::before {
   background-color: #820000; }
 
-.su-main-nav--light .su-main-nav__toggle[aria-expanded="true"]:active::before {
+.su-main-nav.su-main-nav--light .su-main-nav__toggle[aria-expanded="true"]:active::before {
   background-color: #2e2d29; }
 
-.su-main-nav--light ul {
+.su-main-nav.su-main-nav--light ul {
   background-color: #ffffff; }
 
-.su-main-nav--light li a {
+.su-main-nav.su-main-nav--light li a {
   color: #2e2d29;
   border-bottom-color: #d9d9d9; }
-  .su-main-nav--light li a:hover::before, .su-main-nav--light li a:focus::before {
+  .su-main-nav.su-main-nav--light li a:hover::before, .su-main-nav.su-main-nav--light li a:focus::before {
     background-color: #2e2d29; }
-  .su-main-nav--light li a:active {
+  .su-main-nav.su-main-nav--light li a:active {
     color: #820000; }
-    .su-main-nav--light li a:active::before {
+    .su-main-nav.su-main-nav--light li a:active::before {
       background-color: #820000; }
 
-.su-main-nav--light li.su-main-nav__item--current > a {
+.su-main-nav.su-main-nav--light li.su-main-nav__item--current > a {
   color: #820000; }
-  .su-main-nav--light li.su-main-nav__item--current > a::before {
+  .su-main-nav.su-main-nav--light li.su-main-nav__item--current > a::before {
     background-color: #820000; }
 
 @media (max-width: 991px) {
-  .su-main-nav--light li.su-main-nav__item--parent > a::after {
+  .su-main-nav.su-main-nav--light li.su-main-nav__item--parent > a::after {
     background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHRpdGxlPnBsdXMtYmxhY2s8L3RpdGxlPjxwYXRoIGQ9Ik0xMywxYTEsMSwwLDAsMC0yLDBWMTFIMWExLDEsMCwwLDAsMCwySDExVjIzYTEsMSwwLDAsMCwyLDBWMTNIMjNhMSwxLDAsMCwwLDAtMkgxM1oiLz48L3N2Zz4=) no-repeat 0 0;
     background-size: 100%; }
-  .su-main-nav--light li.su-main-nav__item--parent.su-main-nav__item--expanded > a ::after {
+  .su-main-nav.su-main-nav--light li.su-main-nav__item--parent.su-main-nav__item--expanded > a ::after {
     background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAyNCAyNCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMjQgMjQ7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO30KPC9zdHlsZT4KPGxpbmUgY2xhc3M9InN0MCIgeDE9IjIzIiB5MT0iMTEuOSIgeDI9IjEiIHkyPSIxMS45Ii8+Cjwvc3ZnPgo=) no-repeat 0 0;
     background-size: 100%; }
-  .su-main-nav--light li.su-main-nav__item--parent.su-main-nav__item--expanded > a:focus::before {
+  .su-main-nav.su-main-nav--light li.su-main-nav__item--parent.su-main-nav__item--expanded > a:focus::before {
     background-color: transparent; }
-  .su-main-nav--light li.su-main-nav__item--parent.su-main-nav__item--expanded > a[aria-expanded="true"]:hover::before {
+  .su-main-nav.su-main-nav--light li.su-main-nav__item--parent.su-main-nav__item--expanded > a[aria-expanded="true"]:hover::before {
     background-color: #2e2d29; }
-  .su-main-nav--light li.su-main-nav__item--parent.su-main-nav__item--expanded > a[aria-expanded="true"]:active::before {
+  .su-main-nav.su-main-nav--light li.su-main-nav__item--parent.su-main-nav__item--expanded > a[aria-expanded="true"]:active::before {
     background-color: #820000; }
-  .su-main-nav--light li.su-main-nav__item--current.su-main-nav__item--expanded > a {
+  .su-main-nav.su-main-nav--light li.su-main-nav__item--current.su-main-nav__item--expanded > a {
     color: #2e2d29; }
-    .su-main-nav--light li.su-main-nav__item--current.su-main-nav__item--expanded > a::before {
+    .su-main-nav.su-main-nav--light li.su-main-nav__item--current.su-main-nav__item--expanded > a::before {
       background-color: #2e2d29; }
-    .su-main-nav--light li.su-main-nav__item--current.su-main-nav__item--expanded > a:focus::before {
+    .su-main-nav.su-main-nav--light li.su-main-nav__item--current.su-main-nav__item--expanded > a:focus::before {
       background-color: #2e2d29; }
-    .su-main-nav--light li.su-main-nav__item--current.su-main-nav__item--expanded > a[aria-expanded="true"]:active {
+    .su-main-nav.su-main-nav--light li.su-main-nav__item--current.su-main-nav__item--expanded > a[aria-expanded="true"]:active {
       color: #820000; } }
 
 @media only screen and (min-width: 992px) {
-  .su-main-nav--light > ul {
+  .su-main-nav.su-main-nav--light > ul {
     background-color: transparent; }
-    .su-main-nav--light > ul > li > a:hover, .su-main-nav--light > ul > li > a:focus {
+    .su-main-nav.su-main-nav--light > ul > li > a:hover, .su-main-nav.su-main-nav--light > ul > li > a:focus {
       color: #820000; }
-      .su-main-nav--light > ul > li > a:hover::before, .su-main-nav--light > ul > li > a:focus::before {
+      .su-main-nav.su-main-nav--light > ul > li > a:hover::before, .su-main-nav.su-main-nav--light > ul > li > a:focus::before {
         background-color: #820000; }
-    .su-main-nav--light > ul > li > a:active {
+    .su-main-nav.su-main-nav--light > ul > li > a:active {
       color: #2e2d29; }
-      .su-main-nav--light > ul > li > a:active::before {
+      .su-main-nav.su-main-nav--light > ul > li > a:active::before {
         background-color: #2e2d29; }
-    .su-main-nav--light > ul > li > a[aria-expanded="true"] {
+    .su-main-nav.su-main-nav--light > ul > li > a[aria-expanded="true"] {
       color: #2e2d29; }
-      .su-main-nav--light > ul > li > a[aria-expanded="true"]::before {
+      .su-main-nav.su-main-nav--light > ul > li > a[aria-expanded="true"]::before {
         background-color: #b6b1a9; }
-      .su-main-nav--light > ul > li > a[aria-expanded="true"]:hover {
+      .su-main-nav.su-main-nav--light > ul > li > a[aria-expanded="true"]:hover {
         color: #820000; }
-        .su-main-nav--light > ul > li > a[aria-expanded="true"]:hover::before {
+        .su-main-nav.su-main-nav--light > ul > li > a[aria-expanded="true"]:hover::before {
           background-color: #820000; }
-    .su-main-nav--light > ul > li.su-main-nav__item--current > a {
+    .su-main-nav.su-main-nav--light > ul > li.su-main-nav__item--current > a {
       color: #2e2d29; }
-      .su-main-nav--light > ul > li.su-main-nav__item--current > a::before {
+      .su-main-nav.su-main-nav--light > ul > li.su-main-nav__item--current > a::before {
         background-color: #b6b1a9; }
-      .su-main-nav--light > ul > li.su-main-nav__item--current > a:hover, .su-main-nav--light > ul > li.su-main-nav__item--current > a:focus {
+      .su-main-nav.su-main-nav--light > ul > li.su-main-nav__item--current > a:hover, .su-main-nav.su-main-nav--light > ul > li.su-main-nav__item--current > a:focus {
         color: #820000; }
-        .su-main-nav--light > ul > li.su-main-nav__item--current > a:hover::before, .su-main-nav--light > ul > li.su-main-nav__item--current > a:focus::before {
+        .su-main-nav.su-main-nav--light > ul > li.su-main-nav__item--current > a:hover::before, .su-main-nav.su-main-nav--light > ul > li.su-main-nav__item--current > a:focus::before {
           background-color: #820000; }
-    .su-main-nav--light > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a:focus {
+    .su-main-nav.su-main-nav--light > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a:focus {
       color: #2e2d29; }
-      .su-main-nav--light > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a:focus::before {
+      .su-main-nav.su-main-nav--light > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a:focus::before {
         background-color: #b6b1a9; }
-    .su-main-nav--light > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a[aria-expanded="true"]:hover {
+    .su-main-nav.su-main-nav--light > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a[aria-expanded="true"]:hover {
       color: #820000; }
-      .su-main-nav--light > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a[aria-expanded="true"]:hover::before {
+      .su-main-nav.su-main-nav--light > ul > li.su-main-nav__item--current.su-main-nav__item--expanded > a[aria-expanded="true"]:hover::before {
         background-color: #820000; } }
 
 .su-main-nav--mobile-search .su-site-search {

--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -8220,6 +8220,11 @@ a {
         font-weight: 700; }
         .su-main-nav li.su-main-nav__item--current.su-main-nav__item--expanded > a::before {
           background-color: #ffffff; } }
+  @media only screen and (min-width: 768px) and (max-width: 991px) {
+    .su-main-nav > ul {
+      border: none;
+      -webkit-box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.15), 0px 6px 6px rgba(0, 0, 0, 0.2);
+              box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.15), 0px 6px 6px rgba(0, 0, 0, 0.2); } }
   .su-main-nav > ul > li {
     margin-bottom: 0; }
     .su-main-nav > ul > li > a {

--- a/core/src/scss/components/main-nav/_main-nav--dark.scss
+++ b/core/src/scss/components/main-nav/_main-nav--dark.scss
@@ -1,99 +1,51 @@
 @charset "UTF-8";
 
-.su-main-nav--dark {
-  @include grid-media-max('md') {
-    .su-main-nav__toggle {
-      color: $color-white;
+.su-main-nav {
+  &.su-main-nav--dark {
+    @include grid-media-max('md') {
+      .su-main-nav__toggle {
+        color: $color-white;
 
-      &:hover,
-      &:focus {
-        &::before {
-          background-color: $color-white;
+        &:hover,
+        &:focus {
+          &::before {
+            background-color: $color-white;
+          }
         }
-      }
 
-      &:active {
-        &::before {
-          background-color: $color-vivid-red;
-        }
-      }
-
-      &::after {
-        background: url("#{$image-path}/hamburger-white.svg") no-repeat 3px 0;
-      }
-
-      &[aria-expanded="true"] {
-        &::before {
-          background-color: $color-white;
+        &:active {
+          &::before {
+            background-color: $color-vivid-red;
+          }
         }
 
         &::after {
-          background: url("#{$image-path}/close-white.svg") no-repeat 3px 0;
-          background-size: 16px 16px;
+          background: url("#{$image-path}/hamburger-white.svg") no-repeat 3px 0;
         }
 
-        &:hover::before {
-          background-color: $color-vivid-red;
+        &[aria-expanded="true"] {
+          &::before {
+            background-color: $color-white;
+          }
+
+          &::after {
+            background: url("#{$image-path}/close-white.svg") no-repeat 3px 0;
+            background-size: 16px 16px;
+          }
+
+          &:hover::before {
+            background-color: $color-vivid-red;
+          }
         }
       }
     }
-  }
 
-  // desktop first level menu style override
-  > ul {
-    @include grid-media('lg') {
-      > li {
-        > a {
-          color: $color-white;
-
-          &:hover,
-          &:focus {
-            color: $color-white;
-
-            &::before {
-              background-color: $color-white;
-            }
-          }
-
-          &:active {
-            color: $color-white;
-
-            &::before {
-              background-color: $color-white;
-            }
-          }
-
-          &[aria-expanded="true"] {
-            color: $color-white;
-
-            &::before {
-              background-color: $color-white;
-            }
-
-            &:hover {
-              color: $color-white;
-
-              &::before {
-                background-color: $color-vivid-red;
-              }
-            }
-          }
-        }
-
-        &.su-main-nav__item--parent {
-          > a::after {
-            background: url("#{$image-path}/caret-down-white.svg") no-repeat 0 0;
-            background-size: 100%;
-          }
-        }
-
-        &.su-main-nav__item--current {
+    // desktop first level menu style override
+    > ul {
+      @include grid-media('lg') {
+        > li {
           > a {
             color: $color-white;
-
-            &::before {
-              background-color: $color-vivid-red;
-            }
 
             &:hover,
             &:focus {
@@ -103,10 +55,8 @@
                 background-color: $color-white;
               }
             }
-          }
 
-          &.su-main-nav__item--expanded {
-            > a:focus {
+            &:active {
               color: $color-white;
 
               &::before {
@@ -114,11 +64,63 @@
               }
             }
 
-            > a[aria-expanded="true"]:hover {
+            &[aria-expanded="true"] {
+              color: $color-white;
+
+              &::before {
+                background-color: $color-white;
+              }
+
+              &:hover {
+                color: $color-white;
+
+                &::before {
+                  background-color: $color-vivid-red;
+                }
+              }
+            }
+          }
+
+          &.su-main-nav__item--parent {
+            > a::after {
+              background: url("#{$image-path}/caret-down-white.svg") no-repeat 0 0;
+              background-size: 100%;
+            }
+          }
+
+          &.su-main-nav__item--current {
+            > a {
               color: $color-white;
 
               &::before {
                 background-color: $color-vivid-red;
+              }
+
+              &:hover,
+              &:focus {
+                color: $color-white;
+
+                &::before {
+                  background-color: $color-white;
+                }
+              }
+            }
+
+            &.su-main-nav__item--expanded {
+              > a:focus {
+                color: $color-white;
+
+                &::before {
+                  background-color: $color-white;
+                }
+              }
+
+              > a[aria-expanded="true"]:hover {
+                color: $color-white;
+
+                &::before {
+                  background-color: $color-vivid-red;
+                }
               }
             }
           }

--- a/core/src/scss/components/main-nav/_main-nav--light.scss
+++ b/core/src/scss/components/main-nav/_main-nav--light.scss
@@ -1,156 +1,115 @@
 @charset "UTF-8";
 
-.su-main-nav--light {
-  .su-main-nav__toggle {
-    &[aria-expanded="true"] {
-      &::before {
-        background-color: $color-driftwood;
-      }
-
-      &:hover::before {
-        background-color: $color-dark-red;
-      }
-
-      &:active::before {
-        background-color: $color-black;
-      }
-    }
-  }
-
-  // general menu styles
-  ul {
-    background-color: $color-white;
-  }
-
-  li {
-    a {
-      color: $color-black;
-      border-bottom-color: #d9d9d9;
-
-      &:hover,
-      &:focus {
+.su-main-nav {
+  &.su-main-nav--light {
+    .su-main-nav__toggle {
+      &[aria-expanded="true"] {
         &::before {
+          background-color: $color-driftwood;
+        }
+
+        &:hover::before {
+          background-color: $color-dark-red;
+        }
+
+        &:active::before {
           background-color: $color-black;
         }
       }
-
-      &:active {
-        color: $color-dark-red;
-
-        &::before {
-          background-color: $color-dark-red;
-        }
-      }
     }
 
-    &.su-main-nav__item--current {
-      > a {
-        color: $color-dark-red;
-
-        &::before {
-          background-color: $color-dark-red;
-        }
-      }
+    // general menu styles
+    ul {
+      background-color: $color-white;
     }
 
-    @include grid-media-max('md') {
-      &.su-main-nav__item--parent {
-        > a::after {
-          background: url("#{$image-path}/plus-black.svg") no-repeat 0 0;
-          background-size: 100%;
-        }
+    li {
+      a {
+        color: $color-black;
+        border-bottom-color: #d9d9d9;
 
-        &.su-main-nav__item--expanded > a {
-          ::after {
-            background: url("#{$image-path}/minus-black.svg") no-repeat 0 0;
-            background-size: 100%;
-          }
-
-          &:focus::before {
-            background-color: transparent;
-          }
-
-          &[aria-expanded="true"] {
-            &:hover::before {
-              background-color: $color-black;
-            }
-
-            &:active::before {
-              background-color: $color-dark-red;
-            }
-          }
-        }
-      }
-
-      &.su-main-nav__item--current.su-main-nav__item--expanded {
-        > a {
-          color: $color-black;
-
+        &:hover,
+        &:focus {
           &::before {
             background-color: $color-black;
           }
+        }
 
-          &:focus::before {
-            background-color: $color-black;
-          }
+        &:active {
+          color: $color-dark-red;
 
-          &[aria-expanded="true"]:active {
-            color: $color-dark-red;
+          &::before {
+            background-color: $color-dark-red;
           }
         }
       }
-    }
-  }
 
-  // desktop first level menu style override
-  > ul {
-    @include grid-media('lg') {
-      background-color: transparent;
-
-      > li {
+      &.su-main-nav__item--current {
         > a {
-          &:hover,
-          &:focus {
-            color: $color-dark-red;
+          color: $color-dark-red;
 
-            &::before {
-              background-color: $color-dark-red;
-            }
+          &::before {
+            background-color: $color-dark-red;
+          }
+        }
+      }
+
+      @include grid-media-max('md') {
+        &.su-main-nav__item--parent {
+          > a::after {
+            background: url("#{$image-path}/plus-black.svg") no-repeat 0 0;
+            background-size: 100%;
           }
 
-          &:active {
-            color: $color-black;
-
-            &::before {
-              background-color: $color-black;
-            }
-          }
-
-          &[aria-expanded="true"] {
-            color: $color-black;
-
-            &::before {
-              background-color: $color-driftwood;
+          &.su-main-nav__item--expanded > a {
+            ::after {
+              background: url("#{$image-path}/minus-black.svg") no-repeat 0 0;
+              background-size: 100%;
             }
 
-            &:hover {
-              color: $color-dark-red;
+            &:focus::before {
+              background-color: transparent;
+            }
 
-              &::before {
+            &[aria-expanded="true"] {
+              &:hover::before {
+                background-color: $color-black;
+              }
+
+              &:active::before {
                 background-color: $color-dark-red;
               }
             }
           }
         }
 
-        &.su-main-nav__item--current {
+        &.su-main-nav__item--current.su-main-nav__item--expanded {
           > a {
             color: $color-black;
 
             &::before {
-              background-color: $color-driftwood;
+              background-color: $color-black;
             }
 
+            &:focus::before {
+              background-color: $color-black;
+            }
+
+            &[aria-expanded="true"]:active {
+              color: $color-dark-red;
+            }
+          }
+        }
+      }
+    }
+
+    // desktop first level menu style override
+    > ul {
+      @include grid-media('lg') {
+        background-color: transparent;
+
+        > li {
+          > a {
             &:hover,
             &:focus {
               color: $color-dark-red;
@@ -159,22 +118,65 @@
                 background-color: $color-dark-red;
               }
             }
-          }
 
-          &.su-main-nav__item--expanded {
-            > a:focus {
+            &:active {
+              color: $color-black;
+
+              &::before {
+                background-color: $color-black;
+              }
+            }
+
+            &[aria-expanded="true"] {
               color: $color-black;
 
               &::before {
                 background-color: $color-driftwood;
               }
-            }
 
-            > a[aria-expanded="true"]:hover {
-              color: $color-dark-red;
+              &:hover {
+                color: $color-dark-red;
+
+                &::before {
+                  background-color: $color-dark-red;
+                }
+              }
+            }
+          }
+
+          &.su-main-nav__item--current {
+            > a {
+              color: $color-black;
 
               &::before {
-                background-color: $color-dark-red;
+                background-color: $color-driftwood;
+              }
+
+              &:hover,
+              &:focus {
+                color: $color-dark-red;
+
+                &::before {
+                  background-color: $color-dark-red;
+                }
+              }
+            }
+
+            &.su-main-nav__item--expanded {
+              > a:focus {
+                color: $color-black;
+
+                &::before {
+                  background-color: $color-driftwood;
+                }
+              }
+
+              > a[aria-expanded="true"]:hover {
+                color: $color-dark-red;
+
+                &::before {
+                  background-color: $color-dark-red;
+                }
               }
             }
           }

--- a/core/src/scss/components/main-nav/_main-nav--light.scss
+++ b/core/src/scss/components/main-nav/_main-nav--light.scss
@@ -83,20 +83,22 @@
           }
         }
 
-        &.su-main-nav__item--current.su-main-nav__item--expanded {
-          > a {
-            color: $color-black;
+        &.su-main-nav__item--current {
+          &.su-main-nav__item--expanded {
+            > a {
+              color: $color-black;
 
-            &::before {
-              background-color: $color-black;
-            }
+              &::before {
+                background-color: $color-black;
+              }
 
-            &:focus::before {
-              background-color: $color-black;
-            }
+              &:focus::before {
+                background-color: $color-black;
+              }
 
-            &[aria-expanded="true"]:active {
-              color: $color-dark-red;
+              &[aria-expanded="true"]:active {
+                color: $color-dark-red;
+              }
             }
           }
         }

--- a/core/src/scss/components/main-nav/_main-nav.scss
+++ b/core/src/scss/components/main-nav/_main-nav.scss
@@ -167,6 +167,10 @@
 
   //top level menu styles
   > ul {
+    @include grid-media-only('md') {
+      @include box-shadow($depth: 'medium', $stroke: none);
+    }
+
     > li {
       @include margin(null null 0);
 

--- a/core/src/scss/components/main-nav/_main-nav.scss
+++ b/core/src/scss/components/main-nav/_main-nav.scss
@@ -151,12 +151,14 @@
     }
 
     @include grid-media-max('md') {
-      &.su-main-nav__item--current.su-main-nav__item--expanded {
-        > a {
-          font-weight: $font-bold;
+      &.su-main-nav__item--current {
+        &.su-main-nav__item--expanded {
+          > a {
+            font-weight: $font-bold;
 
-          &::before {
-            background-color: $color-white;
+            &::before {
+              background-color: $color-white;
+            }
           }
         }
       }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- I noticed that the color variants (e.g., the --dark version on the decanter website) aren't working properly, e.g., when you click on a parent link item (with downward caret) on the dark variant (the one on decanter website), the caret disappears. This fix should make them behave as intended. Also, tweak the code to work with new linting rules.
- Add drop shadow for MD breakpoint mobile menu (since it doesn't span full width like in xs/sm breakpoints) which helps distinguish menu from the background and it's consistent with 1st level drop down menus on desktop version.

# Needed By (Date)
- N/A

# Urgency
- Sooner the better because the version on the website is acting strange.

# Steps to Test

1. Pull this branch and run `npm run build`
2. Check that the --light and --dark variants are working correctly. Check that at md breakpoint, there is drop shadow around the menu when it's open.
3. Run `npm run sasslint` to check that there are no warnings for the main nav component

# Affected Projects or Products
- Decanter