### PR TITLE
Fix CSS grid gaps not displaying on Edge issue and other minor grid related issues

### DIFF
--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -2339,8 +2339,8 @@ dfn {
 
 .layout-bricks .layout__columns {
   margin: 0 auto;
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-bricks .layout__columns {
       max-width: calc(100% - 40px);
@@ -2546,8 +2546,8 @@ dfn {
 
 .layout-molive > section {
   margin: 0 auto;
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-molive > section {
       max-width: calc(100% - 40px);
@@ -2765,8 +2765,8 @@ dfn {
 
 .layout-bars > div {
   margin: 0 auto;
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-bars > div {
       max-width: calc(100% - 40px);
@@ -2951,8 +2951,8 @@ dfn {
 
 .layout-battleship > div {
   margin: 0 auto;
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-battleship > div {
       max-width: calc(100% - 40px);
@@ -3331,8 +3331,8 @@ dfn {
           margin-bottom: 0; } } }
   @media only screen and (min-width: 576px) {
     .layout-blastila > div {
-      display: grid;
-      display: -ms-grid; } }
+      display: -ms-grid;
+      display: grid; } }
   .layout-blastila > div > aside {
     grid-area: sidebar; }
   .layout-blastila > div > section {
@@ -3515,8 +3515,8 @@ dfn {
           margin-bottom: 0; } } }
   @media (max-width: 991px) {
     .layout-chess > section {
-      display: grid;
       display: -ms-grid;
+      display: grid;
       -ms-grid-columns: 1fr 1fr;
       grid-template-columns: 1fr 1fr; }
       .layout-chess > section > *:nth-child(1) {
@@ -3535,8 +3535,8 @@ dfn {
         -ms-grid-column: 2; } }
   @media only screen and (min-width: 992px) {
     .layout-chess > section {
-      display: grid;
       display: -ms-grid;
+      display: grid;
       -ms-grid-columns: 1fr 1fr 1fr;
       grid-template-columns: 1fr 1fr 1fr; }
       .layout-chess > section > *:nth-child(1) {
@@ -3691,8 +3691,8 @@ dfn {
           margin-bottom: 0; } } }
   @media only screen and (min-width: 576px) {
     .layout-cuttoner > div {
-      display: grid;
       display: -ms-grid;
+      display: grid;
       -ms-grid-columns: 1fr 1fr 1fr;
       grid-template-columns: 1fr 1fr 1fr; } }
   .layout-cuttoner > div > section {
@@ -3808,8 +3808,8 @@ dfn {
             margin-bottom: 0; } } }
     @media only screen and (min-width: 576px) {
       .layout-cuttoner > div > section {
-        display: grid;
         display: -ms-grid;
+        display: grid;
         -ms-grid-column: 2;
         grid-column: 2 / span 2;
         -ms-grid-column-span: 2;
@@ -3984,8 +3984,8 @@ dfn {
           margin-bottom: 0; } } }
   @media only screen and (min-width: 576px) {
     .layout-percles > div {
-      display: grid;
       display: -ms-grid;
+      display: grid;
       -ms-grid-columns: 1fr 1fr 1fr;
       grid-template-columns: 1fr 1fr 1fr; } }
   .layout-percles > div > header {
@@ -4156,8 +4156,8 @@ dfn {
           margin-bottom: 0; } } }
   @media only screen and (min-width: 576px) {
     .layout-robot > div {
-      display: grid;
       display: -ms-grid;
+      display: grid;
       -ms-grid-columns: 1fr 1fr 1fr 1fr;
       grid-template-columns: 1fr 1fr 1fr 1fr; }
       .layout-robot > div > *:nth-child(1) {
@@ -4317,8 +4317,8 @@ dfn {
           margin-bottom: 0; } } }
   @media only screen and (min-width: 576px) {
     .layout-space-invader > div {
-      display: grid;
       display: -ms-grid;
+      display: grid;
       -ms-grid-columns: 1fr 1fr 1fr;
       grid-template-columns: 1fr 1fr 1fr; }
       .layout-space-invader > div > *:nth-child(1) {
@@ -4476,8 +4476,8 @@ dfn {
           margin-bottom: 0; } } }
   @media only screen and (min-width: 576px) {
     .layout-sunset-delorean > div {
-      display: grid;
       display: -ms-grid;
+      display: grid;
       -ms-grid-columns: 1fr 1fr 1fr;
       grid-template-columns: 1fr 1fr 1fr; } }
   .layout-sunset-delorean > div > header {
@@ -4661,8 +4661,8 @@ dfn {
           margin-bottom: 0; } } }
   @media only screen and (min-width: 576px) {
     .layout-thions > div {
-      display: grid;
       display: -ms-grid;
+      display: grid;
       -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
       grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr; }
       .layout-thions > div > *:nth-child(1) {
@@ -4988,8 +4988,8 @@ dfn {
 
 @media only screen and (min-width: 576px) {
   .layout-valmer > section {
-    display: grid;
     display: -ms-grid;
+    display: grid;
     -ms-grid-columns: 1fr 1fr 1fr 1fr;
     grid-template-columns: 1fr 1fr 1fr 1fr; } }
 
@@ -5056,8 +5056,8 @@ dfn {
       width: calc(100% - 200px); } }
 
 .layout-donies > section {
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-donies > section {
       -ms-grid-columns: 1fr;
@@ -5259,8 +5259,8 @@ dfn {
       width: calc(100% - 200px); } }
 
 .layout-frogger > section {
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-frogger > section {
       -ms-grid-columns: 1fr;
@@ -5455,8 +5455,8 @@ dfn {
       width: calc(100% - 200px); } }
 
 .layout-pacman > div {
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-pacman > div {
       -ms-grid-columns: 1fr;
@@ -5686,8 +5686,8 @@ dfn {
       width: calc(100% - 200px); } }
 
 .layout-plakes > div {
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-plakes > div {
       -ms-grid-columns: 1fr;
@@ -5901,8 +5901,8 @@ dfn {
 
 .layout-toucan > div {
   margin: 0 auto;
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-toucan > div {
       max-width: calc(100% - 40px);
@@ -6081,8 +6081,8 @@ dfn {
 
 .layout-trunks > section {
   margin: 0 auto;
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-trunks > section {
       max-width: calc(100% - 40px);
@@ -6296,8 +6296,8 @@ dfn {
 
 .layout-wedge > section {
   margin: 0 auto;
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .layout-wedge > section {
       max-width: calc(100% - 40px);
@@ -6806,8 +6806,8 @@ button,
     color: #2e2d29; }
 
 .su-card--horizontal {
-  display: grid;
-  display: -ms-grid; }
+  display: -ms-grid;
+  display: grid; }
   @media only screen and (min-width: 0) {
     .su-card--horizontal {
       padding: 3.2rem; } }

--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -3194,9 +3194,11 @@ dfn {
 
 .layout-blastila > div {
   margin: 0 auto;
+  -ms-grid-columns: 1fr 1fr 1fr;
   grid-template-columns: 1fr 1fr 1fr;
+  -ms-grid-rows: auto;
   grid-template-rows: auto;
-  grid-template-areas: "sidebar head head" "sidebar A B"; }
+      grid-template-areas: "sidebar head head" "sidebar A B"; }
   @media only screen and (min-width: 0) {
     .layout-blastila > div {
       max-width: calc(100% - 40px);
@@ -3334,16 +3336,26 @@ dfn {
       display: -ms-grid;
       display: grid; } }
   .layout-blastila > div > aside {
+    -ms-grid-row: 1;
+    -ms-grid-row-span: 2;
+    -ms-grid-column: 1;
     grid-area: sidebar; }
   .layout-blastila > div > section {
+    -ms-grid-row: 1;
+    -ms-grid-column: 2;
+    -ms-grid-column-span: 2;
     grid-area: head; }
   .layout-blastila > div :nth-child(3) {
+    -ms-grid-row: 2;
+    -ms-grid-column: 2;
     grid-area: A; }
   .layout-blastila > div :nth-child(4) {
+    -ms-grid-row: 2;
+    -ms-grid-column: 3;
     grid-area: B; }
 
 .layout-blastila--right > div {
-  grid-template-areas: "head head sidebar" "A B sidebar"; }
+      grid-template-areas: "head head sidebar" "A B sidebar"; }
 
 .layout-chess > header,
 .layout-chess > footer {
@@ -3813,17 +3825,51 @@ dfn {
         -ms-grid-column: 2;
         grid-column: 2 / span 2;
         -ms-grid-column-span: 2;
+        -ms-grid-columns: 1fr 1fr;
         grid-template-columns: 1fr 1fr;
+        -ms-grid-rows: auto;
         grid-template-rows: auto;
-        grid-template-areas: "head head" "A B" "foot foot"; } }
+            grid-template-areas: "head head" "A B" "foot foot"; }
+      .layout-cuttoner > div > section > section {
+    -ms-grid-row: 1;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 2; }
+      .layout-cuttoner > div > section > :nth-child(3) {
+    -ms-grid-row: 2;
+    -ms-grid-column: 1; }
+      .layout-cuttoner > div > section > :nth-child(4) {
+    -ms-grid-row: 2;
+    -ms-grid-column: 2; } }
     .layout-cuttoner > div > section > header {
+      -ms-grid-row: 1;
+      -ms-grid-column: 2;
+      -ms-grid-column-span: 2;
       grid-area: head; }
     .layout-cuttoner > div > section > footer {
       grid-area: foot; }
     .layout-cuttoner > div > section :nth-child(2) {
+      -ms-grid-row: 2;
+      -ms-grid-column: 2;
       grid-area: A; }
     .layout-cuttoner > div > section :nth-child(3) {
+      -ms-grid-row: 2;
+      -ms-grid-column: 3;
       grid-area: B; }
+    @media only screen and (min-width: 576px){
+      .layout-cuttoner > div > section > header {
+    -ms-grid-row: 1;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 2; }
+      .layout-cuttoner > div > section > footer {
+    -ms-grid-row: 3;
+    -ms-grid-column: 1;
+    -ms-grid-column-span: 2; }
+      .layout-cuttoner > div > section > :nth-child(2) {
+    -ms-grid-row: 2;
+    -ms-grid-column: 1; }
+      .layout-cuttoner > div > section > :nth-child(3) {
+    -ms-grid-row: 2;
+    -ms-grid-column: 2; } }
   .layout-cuttoner > div > aside {
     -ms-grid-row: 1;
     -ms-grid-column: 3; }

--- a/core/src/scss/utilities/mixins/grid/_display-grid.scss
+++ b/core/src/scss/utilities/mixins/grid/_display-grid.scss
@@ -8,6 +8,6 @@
 // Style guide: Mixins.Grid.display-grid
 //
 @mixin display-grid {
-  display: grid;
   display: -ms-grid;
+  display: grid;
 }

--- a/kss/builder/decanter/kss-assets/css/kss.css
+++ b/kss/builder/decanter/kss-assets/css/kss.css
@@ -414,10 +414,8 @@ sub {
     z-index: 11200; }
 
 .main-page-layout {
-  display: grid;
   display: -ms-grid;
-  display: grid;
-  display: -ms-grid; }
+  display: grid; }
   @media only screen and (min-width: 0) {
     .main-page-layout {
       -ms-grid-columns: 1fr;
@@ -1087,8 +1085,8 @@ body {
           width: calc(100% - 200px); } }
     #kss-node.kss-home .section--dev-resources .cards-container {
       margin: 0 auto;
-      display: grid;
-      display: -ms-grid; }
+      display: -ms-grid;
+      display: grid; }
       @media only screen and (min-width: 0) {
         #kss-node.kss-home .section--dev-resources .cards-container {
           max-width: calc(100% - 40px);
@@ -1313,8 +1311,8 @@ body {
       text-align: center;
       margin-bottom: 60px; }
     #kss-node.kss-home .section--more-info ul {
-      display: grid;
       display: -ms-grid;
+      display: grid;
       margin: 0;
       padding: 0; }
       @media only screen and (min-width: 0) {
@@ -1628,8 +1626,8 @@ body {
   z-index: 20; }
   .masthead div {
     margin: 0 auto;
-    display: grid;
-    display: -ms-grid; }
+    display: -ms-grid;
+    display: grid; }
     @media only screen and (min-width: 0) {
       .masthead div {
         max-width: calc(100% - 40px);

--- a/kss/builder/decanter/kss-assets/css/kss.css
+++ b/kss/builder/decanter/kss-assets/css/kss.css
@@ -1048,10 +1048,6 @@ body {
         #kss-node.kss-home .section--ui-components .su-card {
           max-width: 1500px;
           width: calc(100% - 200px); } }
-      #kss-node.kss-home .section--ui-components .su-card > img {
-        display: block;
-        margin-left: 0;
-        margin-right: 0; }
     #kss-node.kss-home .section--ui-components p {
       max-width: 55%; }
   #kss-node.kss-home .section--dev-resources {

--- a/kss/builder/decanter/scss/_builder.scss
+++ b/kss/builder/decanter/scss/_builder.scss
@@ -14,9 +14,7 @@ $grid-columns: (
 );
 
 .main-page-layout {
-  @include display-grid;
   @include responsive-grid-columns($grid-columns);
-
 }
 
 body:not(.kss-home) .main-page-layout {

--- a/kss/builder/decanter/scss/_home.scss
+++ b/kss/builder/decanter/scss/_home.scss
@@ -75,11 +75,6 @@
       @include centered-column;
       box-shadow: none;
       border: 0;
-      > img {
-        display: block;
-        margin-left: 0;
-        margin-right: 0;
-      }
     }
 
     p {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,6 +84,7 @@ var config = {
               sourceMap: true,
               plugins: () => [
                 autoprefixer( {
+                  grid: true,
                   browsers: [ 'last 2 versions', 'ie 11' ]
                 } )
               ]


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Currently grid gaps are not displaying on Edge. Putting `display: -ms-grid` before `display: grid`  in the mixin `@display-grid` fixes the issue because Edge was using the older `display: -ms-grid`.
- The Blastila layout isn't displaying correctly on IE. All sections are overlapping due to the use of `grid-template-areas` which needs autoprefixer to have grid support. This PR switch the grid support for autoprefixer on which fixes the issue.
- There is a redundant call to `@display-grid` on the homepage (`display-grid` is already included in `@responsive-grid-columns`, no need to call it separately again).

# Needed By (Date)
- Sooner would be better

# Urgency
- N/A

# Steps to Test

1. Pull this branch and run `npm run build`
2. Check on Edge or Browserstack that the grid gaps are showing up
2. Check on IE11 that the CSS grid version of the Blastila layout is rendering correctly with no overlapping sections.

# Affected Projects or Products
- Decanter

# Associated Issues and/or People
- #412 
