### PR TITLE
Fix skiplink target so it doesn't take up space and cause overflow

### DIFF
--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -8768,5 +8768,17 @@ a {
     width: auto;
     z-index: 11222; }
 
+.su-skiplinks__target {
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(100%);
+          clip-path: inset(100%);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px; }
+
 
 /*# sourceMappingURL=decanter.css.map*/

--- a/core/src/scss/components/skiplinks/_skiplinks.scss
+++ b/core/src/scss/components/skiplinks/_skiplinks.scss
@@ -19,7 +19,7 @@
 //   <a href="#main-content" class="su-skiplinks">Skip to main content</a>
 // </header>
 //  <main>
-//   <h2 id="main-content" class="su-sr-only-text" tabindex="-1">Main Content</h2>
+//   <h2 id="main-content" class="su-skiplinks__target" tabindex="-1">Main Content</h2>
 // </main>
 //
 //
@@ -28,4 +28,8 @@
 //
 .su-skiplinks {
   @include skiplinks;
+}
+
+.su-skiplinks__target {
+  @include hide-visually;
 }

--- a/core/src/scss/core/helpers/_sr-only-text.scss
+++ b/core/src/scss/core/helpers/_sr-only-text.scss
@@ -3,7 +3,9 @@
 //
 // Screen Reader Only Text
 //
-// Hides the text in an element, commonly used to show an image instead.
+// Use this helper only for text that describes an image but should be hidden visually. For other use cases where
+// text needs to be hidden visually (e.g., skip link targets), use the .su-sr-only-element helper class instead.
+//
 // Some elements will need block-level styles applied.
 //
 // Style guide: Core.Helpers.sr-only

--- a/core/src/templates/components/skiplinks/target.twig
+++ b/core/src/templates/components/skiplinks/target.twig
@@ -13,4 +13,4 @@
  *   skiplink - defaults to 'Main Content'
  */
 #}
-<h2 {{ attributes }} id="{{ target_id|default('su-main-content-1891') }}" class="su-sr-only-text {{ modifier_class }}" tabindex="-1">{{ target_text|default('Main Content') }}</h2>
+<h2 {{ attributes }} id="{{ target_id|default('su-main-content-1891') }}" class="su-skiplinks__target {{ modifier_class }}" tabindex="-1">{{ target_text|default('Main Content') }}</h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decanter",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "decanter",
   "description": "Pattern Library and CSS Framework.",
   "author": "",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "homepage": "https://github.com/SU-SWS/decanter",
   "license": "MIT",
   "srcDir": "core/src/",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "decanter",
   "description": "Pattern Library and CSS Framework.",
   "author": "",
-  "version": "5.1.0",
+  "version": "5.0.1",
   "homepage": "https://github.com/SU-SWS/decanter",
   "license": "MIT",
   "srcDir": "core/src/",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The skiplink target was using the `.su-sr-only-text` class which uses the Bourbon `@hide-text` mixin which takes up space and causes overflow. This PR creates new class `.su-skiplinks__target` which uses the `@hide-visually` mixin instead which has the style code we need. The skip link target now has proper styles (same as current best practice).
- I didn't just use the `.su-sr-only-element` class on the skip link target directly because .su-sr-only-element unhides on focus.
- Add documentation for `.su-sr-only-text` - it's only good for cases where e.g., hide the SR text in the site-search component magnifying glass button/icon.

# Needed By (Date)
- ASAP

# Urgency
- Pretty urgent

# Steps to Test
1. Pull this branch and run `npm run build`.
2. Look at the skiplink target in the skiplinks component. It should now now take up any spaces.


# Affected Projects or Products
- Decanter

# Associated Issues and/or People
- #414 