### PR TITLE
Node v12.4.0 support for node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery": "^3.3.1",
     "kss": "^3.0.0-beta.25",
     "mini-css-extract-plugin": "^0.5.0",
-    "node-sass": "^4.11.0",
+    "node-sass": "~4.12",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "postcss-loader": "^3.0.0",
     "sass-lint": "^1.12.1",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update node-sass version to support node 12
- https://github.com/sass/node-sass/issues/2632
- Not everyone is using NVM

# Needed By (Date)
- End of the week?

# Urgency
- low

# Steps to Test

1. Check out this branch
2. Run `npm install`
3. Ensure version `4.12.0` gets installed 

# Affected Projects or Products
- NPM commands

# Associated Issues and/or People
-  @rebeccahongsf 
- https://github.com/sass/node-sass/issues/2632

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
