### PR TITLE
Hide image on xs breakpoint for .su-card--link

### DIFF
--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -364,7 +364,7 @@ button,
   display: block;
   background-color: #ffffff; }
   @media only screen and (min-width: 0) and (max-width: 575px) {
-    .su-card > img {
+    .su-card img {
       display: none; } }
   .su-card .su-card__contents {
     font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Arial", sans-serif; }

--- a/core/src/scss/utilities/placeholders/components/_card.scss
+++ b/core/src/scss/utilities/placeholders/components/_card.scss
@@ -13,7 +13,7 @@
   display: block;
   background-color: color(bg);
 
-  > img {
+  img {
     // Hide the image on the smallest screen sizes.
     @include grid-media-only('xs') {
       display: none;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix for .su-card--link variant so that it hides image at xs breakpoint for both vertical and horizontal variant.

# Needed By (Date)
- Sooner the better

# Urgency
- N/A

# Steps to Test

1. Pull this branch and compile styleguide
2. Check that the `.su-card--link` variant hides image at XS breakpoint. Add the .su-card--horizontal modifier class and check that it still behave the same.

# Affected Projects or Products
- Decanter

# Associated Issues and/or People
- #430 
