### PR TITLE
Add 'paper' option for box-shadow mixin

### DIFF
--- a/core/src/scss/utilities/variables/core/_box-shadow.scss
+++ b/core/src/scss/utilities/variables/core/_box-shadow.scss
@@ -8,6 +8,7 @@
 //<pre>
 // $box-shadow-depth: (
 //   'flat': '',
+//   'paper': '0px 1px 2px rgba(0, 0, 0, 0.25)',
 //   'shallow': '0px 3px 6px rgba(0, 0, 0, 0.13), 0px 3px 6px rgba(0, 0, 0, 0.1)',
 //   'medium': '0px 10px 20px rgba(0, 0, 0, 0.15), 0px 6px 6px rgba(0, 0, 0, 0.2)',
 //   'medium-deep': '0px 14px 28px rgba(0, 0, 0, 0.2), 0px 5px 10px rgba(0, 0, 0, 0.22)',
@@ -19,6 +20,7 @@
 //
 $box-shadow-depth: (
   'flat': 'none',
+  'paper': '0px 1px 2px rgba(0, 0, 0, 0.25)',
   'shallow': '0px 3px 6px rgba(0, 0, 0, 0.13), 0px 3px 6px rgba(0, 0, 0, 0.1)',
   'medium': '0px 10px 20px rgba(0, 0, 0, 0.15), 0px 6px 6px rgba(0, 0, 0, 0.2)',
   'medium-deep': '0px 14px 28px rgba(0, 0, 0, 0.2), 0px 5px 10px rgba(0, 0, 0, 0.22)',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding a `'paper'` option for `$box-shadow-depth` variable map as requested by Kerri.

# Needed By (Date)
- When ready

# Urgency
- N/A

# Steps to Test

1. Pull this branch and build styleguide
2. In placeholder `%card-base`, change the `@box-shadow` `$depth` parameter from `'shallow'` to `'paper'`
3. Compile styleguide and check the card components section. See that the cards are now rendering the new 'paper' drop shadow.

# Affected Projects or Products
- SWS SoE department site uses this type of shadow

# Associated Issues and/or People
- #468