### PR TITLE
THEME-15: DateStacked: replace <span> with <time>.

### DIFF
--- a/core/src/templates/components/date-stacked/date-stacked.twig
+++ b/core/src/templates/components/date-stacked/date-stacked.twig
@@ -15,11 +15,11 @@
 
 <div{{ attributes }} class="su-date-stacked {{ modifier_class }}">
   {% if month_of_year is not empty %}
-    <span class="su-date-stacked__month">{{ month_of_year }}</span>
+    <time class="su-date-stacked__month">{{ month_of_year }}</time>
   {% endif %}
 
   {% if day_of_month is not empty %}
-    <span class="su-date-stacked__day">{{ day_of_month }}</span>
+    <time class="su-date-stacked__day">{{ day_of_month }}</time>
   {% endif %}
 
 </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This proposes the use of <time> in lieu of <span> for the Date Stacked component.

# Needed By (Date)


# Urgency
Not urgent

# Steps to Test

Check out this branch
Verify that the `<time>` element is used by the Date Stacked component

# Affected Projects or Products
Decanter

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/THEME-15
- Other PRs:
https://github.com/SU-SWS/decanter/pull/421

- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time

- Anyone who should be notified? 
@buttonwillowsix 
@yvonnetangsu 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
