### PR TITLE
THEME-15: Hero: replace <div> with <<section>

### DIFF
--- a/core/src/templates/components/hero/hero.twig
+++ b/core/src/templates/components/hero/hero.twig
@@ -22,7 +22,7 @@
  * - hero_button_label: The text label of the button component.
  */
 #}
-<div{{ attributes }} class="su-hero {{ modifier_class }}">
+<section{{ attributes }} class="su-hero {{ modifier_class }}">
 
   {# Hero Image or Video #}
   <div class="su-hero__media">
@@ -51,4 +51,4 @@
     only
   %}
 
-</div>
+</section>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This proposes the use of `<section>` in lieu of the initial `<div>` for the hero component

# Needed By (Date)

# Urgency
- Discussion first.

# Steps to Test

1. Checkout this branch
1. Navigate to the Hero component
1. Verify that the `<section>` element is the first element of the Hero component

# Affected Projects or Products
- Decanter

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/THEME-15
- Other PRs: https://github.com/SU-SWS/decanter/pull/421
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
- Anyone who should be notified? (`@mention` them here)
@buttonwillowsix 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
