### PR TITLE
Scale down type-a and type-b font size at xs and sm breakpoints, repurpose splash font and minor typography tweaks

### DIFF
--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -3089,6 +3089,46 @@ dfn {
     .su-small-paragraph {
       font-size: 1.5rem; } }
 
+*[class^="su-type"] {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  margin-top: 0;
+  clear: both;
+  font-weight: 700;
+  line-height: 1.2; }
+  *[class^="su-type"] a {
+    text-decoration: none;
+    font-weight: 700; }
+
+.su-type-a {
+  font-size: 2.44140625em;
+  letter-spacing: -0.016em; }
+  @media (max-width: 767px) {
+    .su-type-a {
+      font-size: 2.0751953125em; } }
+
+.su-type-b {
+  font-size: 1.953125em;
+  letter-spacing: -0.016em; }
+  @media (max-width: 767px) {
+    .su-type-b {
+      font-size: 1.66015625em; } }
+
+.su-type-c {
+  font-size: 1.5625em;
+  letter-spacing: -0.012em; }
+
+.su-type-d {
+  font-size: 1.25em;
+  letter-spacing: -0.01em; }
+
+.su-type-e {
+  font-size: 1em; }
+
+.su-type-f {
+  font-size: 0.8em;
+  text-transform: uppercase; }
+
 .layout-blastila-flex--right > div {
   -webkit-box-orient: horizontal;
   -webkit-box-direction: reverse;

--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -2974,7 +2974,9 @@ h2,
 h3,
 h4,
 h5,
-h6 {
+h6,
+*[class^="su-type"],
+.su-font-splash {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   margin-top: 0;
@@ -2986,36 +2988,46 @@ h6 {
   h3 a,
   h4 a,
   h5 a,
-  h6 a {
+  h6 a,
+  *[class^="su-type"] a,
+  .su-font-splash a {
     text-decoration: none;
     font-weight: 700; }
 
-h1 {
+h1,
+.su-type-a {
   font-size: 2.44140625em;
   letter-spacing: -0.016em; }
   @media (max-width: 767px) {
-    h1 {
+    h1,
+    .su-type-a {
       font-size: 2.0751953125em; } }
 
-h2 {
+h2,
+.su-type-b {
   font-size: 1.953125em;
   letter-spacing: -0.016em; }
   @media (max-width: 767px) {
-    h2 {
+    h2,
+    .su-type-b {
       font-size: 1.66015625em; } }
 
-h3 {
+h3,
+.su-type-c {
   font-size: 1.5625em;
   letter-spacing: -0.012em; }
 
-h4 {
+h4,
+.su-type-d {
   font-size: 1.25em;
   letter-spacing: -0.01em; }
 
-h5 {
+h5,
+.su-type-e {
   font-size: 1em; }
 
-h6 {
+h6,
+.su-type-f {
   font-size: 0.8em;
   text-transform: uppercase; }
 
@@ -3050,14 +3062,12 @@ dfn {
   letter-spacing: -0.012em; }
 
 .su-font-splash {
-  font-size: 2.44140625em;
+  font-size: 3.0517578125em;
   margin-bottom: 0;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   letter-spacing: -0.016em; }
-  @media only screen and (min-width: 768px) {
+  @media (max-width: 767px) {
     .su-font-splash {
-      font-weight: 700; } }
+      font-size: 2.5939941406em; } }
 
 .su-caption {
   margin-top: 0;
@@ -3088,46 +3098,6 @@ dfn {
   @media (max-width: 767px) {
     .su-small-paragraph {
       font-size: 1.5rem; } }
-
-*[class^="su-type"] {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  margin-top: 0;
-  clear: both;
-  font-weight: 700;
-  line-height: 1.2; }
-  *[class^="su-type"] a {
-    text-decoration: none;
-    font-weight: 700; }
-
-.su-type-a {
-  font-size: 2.44140625em;
-  letter-spacing: -0.016em; }
-  @media (max-width: 767px) {
-    .su-type-a {
-      font-size: 2.0751953125em; } }
-
-.su-type-b {
-  font-size: 1.953125em;
-  letter-spacing: -0.016em; }
-  @media (max-width: 767px) {
-    .su-type-b {
-      font-size: 1.66015625em; } }
-
-.su-type-c {
-  font-size: 1.5625em;
-  letter-spacing: -0.012em; }
-
-.su-type-d {
-  font-size: 1.25em;
-  letter-spacing: -0.01em; }
-
-.su-type-e {
-  font-size: 1em; }
-
-.su-type-f {
-  font-size: 0.8em;
-  text-transform: uppercase; }
 
 .layout-blastila-flex--right > div {
   -webkit-box-orient: horizontal;

--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -406,9 +406,11 @@ button,
         .su-card .su-card__contents > span {
           margin-bottom: 0.95rem; } }
       .su-card .su-card__contents > span a {
-        text-decoration: none; }
+        text-decoration: none;
+        font-weight: 700; }
     .su-card .su-card__contents > h2 {
-      font-size: 1.5625em; }
+      font-size: 1.5625em;
+      letter-spacing: -0.012em; }
       @media only screen and (min-width: 0) {
         .su-card .su-card__contents > h2 {
           margin-bottom: 1.06666672rem; } }
@@ -485,6 +487,7 @@ button,
     background-color: #b1040e;
     color: #ffffff;
     font-size: 1.5625em;
+    letter-spacing: -0.012em;
     padding: 1.5rem 3rem 1.8rem;
     margin-bottom: 0;
     font-weight: 400; }
@@ -2677,7 +2680,11 @@ fieldset {
 
 legend {
   font-size: 1.953125em;
+  letter-spacing: -0.016em;
   font-weight: 700; }
+  @media (max-width: 767px) {
+    legend {
+      font-size: 1.66015625em; } }
 
 .su-fieldset-inputs label {
   margin-top: 0; }
@@ -2980,19 +2987,30 @@ h6 {
   h4 a,
   h5 a,
   h6 a {
-    text-decoration: none; }
+    text-decoration: none;
+    font-weight: 700; }
 
 h1 {
-  font-size: 2.44140625em; }
+  font-size: 2.44140625em;
+  letter-spacing: -0.016em; }
+  @media (max-width: 767px) {
+    h1 {
+      font-size: 2.0751953125em; } }
 
 h2 {
-  font-size: 1.953125em; }
+  font-size: 1.953125em;
+  letter-spacing: -0.016em; }
+  @media (max-width: 767px) {
+    h2 {
+      font-size: 1.66015625em; } }
 
 h3 {
-  font-size: 1.5625em; }
+  font-size: 1.5625em;
+  letter-spacing: -0.012em; }
 
 h4 {
-  font-size: 1.25em; }
+  font-size: 1.25em;
+  letter-spacing: -0.01em; }
 
 h5 {
   font-size: 1em; }
@@ -3028,13 +3046,15 @@ dfn {
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
   line-height: 1.5;
-  max-width: 85rem; }
+  max-width: 85rem;
+  letter-spacing: -0.012em; }
 
 .su-font-splash {
   font-size: 2.44140625em;
   margin-bottom: 0;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; }
+  -moz-osx-font-smoothing: grayscale;
+  letter-spacing: -0.016em; }
   @media only screen and (min-width: 768px) {
     .su-font-splash {
       font-weight: 700; } }
@@ -7685,6 +7705,7 @@ button,
   background-color: #b1040e;
   color: #ffffff;
   font-size: 1.5625em;
+  letter-spacing: -0.012em;
   padding: 1.5rem 3rem 1.8rem; }
   .su-button--big:hover, .su-button--big:focus,
   .su-button--big.su-link:hover,
@@ -8018,9 +8039,14 @@ button,
     font-weight: 700;
     line-height: 1.2;
     font-size: 1.953125em;
+    letter-spacing: -0.016em;
     display: block; }
     .su-date-stacked .su-date-stacked__day a {
-      text-decoration: none; }
+      text-decoration: none;
+      font-weight: 700; }
+    @media (max-width: 767px) {
+      .su-date-stacked .su-date-stacked__day {
+        font-size: 1.66015625em; } }
 
 .su-date-stacked--no-background {
   padding: 0;

--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -2975,8 +2975,7 @@ h3,
 h4,
 h5,
 h6,
-*[class^="su-type"],
-.su-font-splash {
+*[class^="su-type"] {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   margin-top: 0;
@@ -2989,8 +2988,7 @@ h6,
   h4 a,
   h5 a,
   h6 a,
-  *[class^="su-type"] a,
-  .su-font-splash a {
+  *[class^="su-type"] a {
     text-decoration: none;
     font-weight: 700; }
 
@@ -3062,9 +3060,18 @@ dfn {
   letter-spacing: -0.012em; }
 
 .su-font-splash {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  margin-top: 0;
+  clear: both;
+  font-weight: 700;
+  line-height: 1.2;
   font-size: 3.0517578125em;
   margin-bottom: 0;
   letter-spacing: -0.016em; }
+  .su-font-splash a {
+    text-decoration: none;
+    font-weight: 700; }
   @media (max-width: 767px) {
     .su-font-splash {
       font-size: 2.5939941406em; } }

--- a/core/src/scss/elements/typography/_typography.scss
+++ b/core/src/scss/elements/typography/_typography.scss
@@ -48,8 +48,7 @@ h3,
 h4,
 h5,
 h6,
-*[class^="su-type"],
-.su-font-splash {
+*[class^="su-type"] {
   @include types;
 }
 

--- a/core/src/scss/elements/typography/_typography.scss
+++ b/core/src/scss/elements/typography/_typography.scss
@@ -7,6 +7,7 @@
 // paragraphs and headings. Also includes special type treatment classes such as
 // splash font and lead font.
 //
+// .su-font-splash        - Splash Font
 // .su-type-a             - Display Type A (used for H1 heading)
 // .su-type-b             - Display Type B (used for H2 heading)
 // .su-type-c             - Display Type C (used for H3 heading)
@@ -14,7 +15,6 @@
 // .su-type-e             - Display Type E (used for H5 heading)
 // .su-type-f             - Display Type F (used for H6 heading)
 // .su-intro-text         - Intro Text
-// .su-font-splash        - Splash Font
 // .su-caption            - Caption Font
 // .su-credits            - Credits Font
 // .su-subheading         - Subheading Font
@@ -47,31 +47,39 @@ h2,
 h3,
 h4,
 h5,
-h6 {
+h6,
+*[class^="su-type"],
+.su-font-splash {
   @include types;
 }
 
-h1 {
+h1,
+.su-type-a {
   @include type-a;
 }
 
-h2 {
+h2,
+.su-type-b {
   @include type-b;
 }
 
-h3 {
+h3,
+.su-type-c {
   @include type-c;
 }
 
-h4 {
+h4,
+.su-type-d {
   @include type-d;
 }
 
-h5 {
+h5,
+.su-type-e {
   @include type-e;
 }
 
-h6 {
+h6,
+.su-type-f {
   @include type-f;
 }
 
@@ -134,32 +142,4 @@ dfn {
 
 .su-small-paragraph {
   @include small-paragraph;
-}
-
-*[class^="su-type"] {
-  @include types;
-}
-
-.su-type-a {
-  @include type-a;
-}
-
-.su-type-b {
-  @include type-b;
-}
-
-.su-type-c {
-  @include type-c;
-}
-
-.su-type-d {
-  @include type-d;
-}
-
-.su-type-e {
-  @include type-e;
-}
-
-.su-type-f {
-  @include type-f;
 }

--- a/core/src/scss/elements/typography/_typography.scss
+++ b/core/src/scss/elements/typography/_typography.scss
@@ -7,6 +7,12 @@
 // paragraphs and headings. Also includes special type treatment classes such as
 // splash font and lead font.
 //
+// .su-type-a             - Display Type A (used for H1 heading)
+// .su-type-b             - Display Type B (used for H2 heading)
+// .su-type-c             - Display Type C (used for H3 heading)
+// .su-type-d             - Display Type D (used for H4 heading)
+// .su-type-e             - Display Type E (used for H5 heading)
+// .su-type-f             - Display Type F (used for H6 heading)
 // .su-intro-text         - Intro Text
 // .su-font-splash        - Splash Font
 // .su-caption            - Caption Font
@@ -128,4 +134,32 @@ dfn {
 
 .su-small-paragraph {
   @include small-paragraph;
+}
+
+*[class^="su-type"] {
+  @include types;
+}
+
+.su-type-a {
+  @include type-a;
+}
+
+.su-type-b {
+  @include type-b;
+}
+
+.su-type-c {
+  @include type-c;
+}
+
+.su-type-d {
+  @include type-d;
+}
+
+.su-type-e {
+  @include type-e;
+}
+
+.su-type-f {
+  @include type-f;
 }

--- a/core/src/scss/utilities/mixins/typography/_font-splash.scss
+++ b/core/src/scss/utilities/mixins/typography/_font-splash.scss
@@ -8,6 +8,7 @@
 // Style guide: Mixins.Typography.font-splash
 //
 @mixin font-splash {
+  @include types;
   @include modular-typography(5);
   @include margin(null null 0);
   letter-spacing: -0.016em;

--- a/core/src/scss/utilities/mixins/typography/_font-splash.scss
+++ b/core/src/scss/utilities/mixins/typography/_font-splash.scss
@@ -8,12 +8,11 @@
 // Style guide: Mixins.Typography.font-splash
 //
 @mixin font-splash {
-  @include modular-typography(4);
+  @include modular-typography(5);
   @include margin(null null 0);
-  @include font-smoothing;
   letter-spacing: -0.016em;
 
-  @media #{$su-breakpoint-md} {
-    font-weight: $su-font-bold;
+  @include grid-media-max('sm') {
+    font-size: modular-scale(5) * $su-displays-mobile-factor;
   }
 }

--- a/core/src/scss/utilities/mixins/typography/_font-splash.scss
+++ b/core/src/scss/utilities/mixins/typography/_font-splash.scss
@@ -11,6 +11,7 @@
   @include modular-typography(4);
   @include margin(null null 0);
   @include font-smoothing;
+  letter-spacing: -0.016em;
 
   @media #{$su-breakpoint-md} {
     font-weight: $su-font-bold;

--- a/core/src/scss/utilities/mixins/typography/_intro-text.scss
+++ b/core/src/scss/utilities/mixins/typography/_intro-text.scss
@@ -15,4 +15,5 @@
   font-weight: $su-font-regular;
   line-height: $su-intro-line-height;
   max-width: $su-intro-max-width;
+  letter-spacing: -0.012em;
 }

--- a/core/src/scss/utilities/mixins/typography/_type-a.scss
+++ b/core/src/scss/utilities/mixins/typography/_type-a.scss
@@ -9,4 +9,9 @@
 //
 @mixin type-a {
   @include modular-typography(4);
+  letter-spacing: -0.016em;
+
+  @include grid-media-max('sm') {
+    font-size: modular-scale(4) * $su-displays-mobile-factor;
+  }
 }

--- a/core/src/scss/utilities/mixins/typography/_type-b.scss
+++ b/core/src/scss/utilities/mixins/typography/_type-b.scss
@@ -9,4 +9,9 @@
 //
 @mixin type-b {
   @include modular-typography(3);
+  letter-spacing: -0.016em;
+
+  @include grid-media-max('sm') {
+    font-size: modular-scale(3) * $su-displays-mobile-factor;
+  }
 }

--- a/core/src/scss/utilities/mixins/typography/_type-c.scss
+++ b/core/src/scss/utilities/mixins/typography/_type-c.scss
@@ -9,4 +9,5 @@
 //
 @mixin type-c {
   @include modular-typography(2);
+  letter-spacing: -0.012em;
 }

--- a/core/src/scss/utilities/mixins/typography/_type-d.scss
+++ b/core/src/scss/utilities/mixins/typography/_type-d.scss
@@ -9,4 +9,5 @@
 //
 @mixin type-d {
   @include modular-typography(1);
+  letter-spacing: -0.01em;
 }

--- a/core/src/scss/utilities/mixins/typography/_types.scss
+++ b/core/src/scss/utilities/mixins/typography/_types.scss
@@ -17,5 +17,6 @@
 
   a {
     text-decoration: none;
+    font-weight: $su-font-bold;
   }
 }

--- a/core/src/scss/utilities/mixins/typography/index.scss
+++ b/core/src/scss/utilities/mixins/typography/index.scss
@@ -9,6 +9,7 @@
 //
 
 @import
+'types',
 'big-paragraph',
 'caption',
 'credits',
@@ -28,5 +29,5 @@
 'type-c',
 'type-d',
 'type-e',
-'type-f',
-'types';
+'type-f'
+;

--- a/core/src/scss/utilities/mixins/typography/index.scss
+++ b/core/src/scss/utilities/mixins/typography/index.scss
@@ -29,5 +29,4 @@
 'type-c',
 'type-d',
 'type-e',
-'type-f'
-;
+'type-f';

--- a/core/src/scss/utilities/variables/core/_typography.scss
+++ b/core/src/scss/utilities/variables/core/_typography.scss
@@ -49,6 +49,17 @@ $su-base-font-size: 2rem !default;
 $base-font-size: $su-base-font-size !default;
 
 //
+// $su-displays-mobile-factor
+//
+// A multiplier to scale down some of the larger display font sizes at XS and SM break points.
+//
+// Markup: $su-displays-mobile-factor: 0.85 !default;
+//
+// Style guide: Variables.Core.Typography.su-displays-mobile-factor
+//
+$su-displays-mobile-factor: 0.85 !default;
+
+//
 // $su-base-line-height
 //
 // Default line height.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Introduce a multiplier `$su-displays-mobile-factor` of 0.85 to scale down `@type-a` (h1) and `@type-b `(h2) and font-splash font sizes at `xs` and `sm` breakpoints.
- Repurpose `@font-splash`/`.su-font-splash` into a display type style that's more splashy - larger than h1 (modular-scale(5)).
- Finetune letter spacing of display types (approved by Kerri Augenstein).
- Add 6 Decanter class names `.su-type-a`, `.su-type-b` etc so developers can use them with the decanter.css file. Also add them to the styleguide.
- Other minor typography tweaks.

# Needed By (Date)
- N/A

# Urgency
- Not urgent

# Steps to Test

1. Pull this branch and build styleguide
2. Look at section Elements/Typography and check that the 6 new display styles (`.su-type-a` etc) are on the styleguide.
3. Check that for Display Type A and Type B, the font size scale down as discussed at `xs` and `sm` breakpoints.
4. Check that the new splash font style looks ok.
5. Check that the new letter-spacing finetuning looks ok and consistent with our other type styles.

# Affected Projects or Products
- Redwood WordPress
- Decanter

# Associated Issues and/or People
- #471 
- #501 
- @kerri-augenstein 