### PR TITLE
Update _hero.scss

### DIFF
--- a/core/src/scss/components/hero/_hero.scss
+++ b/core/src/scss/components/hero/_hero.scss
@@ -48,6 +48,7 @@ $_su-hero-height: (
   background: $su-color-black;
   height: 100%;
   width: 100%;
+  overflow: hidden;
 
   @include grid-media('md') {
     min-height: map-get($_su-hero-height, 'md');

--- a/core/src/templates/components/hero/hero.twig
+++ b/core/src/templates/components/hero/hero.twig
@@ -43,7 +43,14 @@
     {{ hero_image}}
     {% endif %}
   </div>
-
+  {# Only include the card template if there is content to render. #}
+  {%- if
+    hero_super_headline is not empty or
+    hero_headline is not empty or
+    hero_body is not empty or
+    hero_cta_label is not empty or
+    hero_button_label is not empty
+  -%}
   {# We reuse the card component here. #}
   {% include template_path_card with
     {
@@ -59,5 +66,5 @@
     }
     only
   %}
-
+  {%- endif -%}
 </div>


### PR DESCRIPTION
# READY FOR REVIEW/

# Summary
- hides overflow of images larger than the max height of the banner. 
- Don't render an empty card wrapper when no card content is provided.

# Review By (Date)
- October 22

# Urgency
- Low, but it is a bug.

# Steps to Test

1. Modify the test image for the hero banner to be 1000px tall
2. Compile the styleguide and see the overflow
3. check out this branch
4. Compile the styleguide and see the image overflow as hidden
5. Win.

# Affected Projects or Products
- D8CORE 
- Wordpress theme.

# Associated Issues and/or People
- 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
