### PR TITLE
Use percentage for html root font size instead of px

### DIFF
--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -3007,7 +3007,7 @@ table {
 
 html {
   font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-  font-size: 10px; }
+  font-size: 62.5%; }
 
 body {
   color: #2e2d29; }

--- a/core/src/scss/utilities/variables/core/_typography.scss
+++ b/core/src/scss/utilities/variables/core/_typography.scss
@@ -9,13 +9,13 @@
 //
 // $su-root-font-size
 //
-// Font size.
+// HTML root font size (10px assuming browser default is 16px)
 //
-// Markup: $su-root-font-size: 10px;
+// Markup: $su-root-font-size: 62.5%;
 //
 // Style guide: Variables.Core.Typography.su-root-font-size
 //
-$su-root-font-size: 10px;
+$su-root-font-size: 62.5%;
 
 //
 // <del>$root-font-size</del>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use 62.5% for html font size instead of 10px, so people who set font size preferences in their browser can see elements scaling up.

# Needed By (Date)
- Sooner the better

# Urgency
- Not urgent

# Steps to Test

1. Pull this branch and compile styleguide
2. Check that no rendered font sizes has changed compared to the live decanter site.

# Affected Projects or Products
- Decanter
