### PR TITLE
Use unit rem instead of em for big button font size

### DIFF
--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -486,9 +486,8 @@ button,
     padding: 1rem 2rem 1.15rem;
     background-color: #b1040e;
     color: #ffffff;
-    font-size: 1.5625em;
-    letter-spacing: -0.012em;
-    padding: 1.5rem 3rem 1.8rem;
+    padding: 1.3rem 2.8rem 1.5rem;
+    font-size: 2.5rem;
     margin-bottom: 0;
     font-weight: 400; }
     .su-cta .su-cta__button:hover, .su-cta .su-cta__button:focus {
@@ -497,6 +496,13 @@ button,
     .su-cta .su-cta__button:focus {
       -webkit-box-shadow: 0 0 3px #4d4f53, 0 0 7px #4d4f53;
               box-shadow: 0 0 3px #4d4f53, 0 0 7px #4d4f53; }
+    @media only screen and (min-width: 768px) {
+      .su-cta .su-cta__button {
+        padding: 1.5rem 3rem 1.8rem;
+        font-size: 2.8rem; } }
+    @media only screen and (min-width: 1500px) {
+      .su-cta .su-cta__button {
+        font-size: 3rem; } }
     @media only screen and (min-width: 0) {
       .su-cta .su-cta__button {
         width: 100%;
@@ -7787,9 +7793,8 @@ button,
   padding: 1rem 2rem 1.15rem;
   background-color: #b1040e;
   color: #ffffff;
-  font-size: 1.5625em;
-  letter-spacing: -0.012em;
-  padding: 1.5rem 3rem 1.8rem; }
+  padding: 1.3rem 2.8rem 1.5rem;
+  font-size: 2.5rem; }
   .su-button--big:hover, .su-button--big:focus,
   .su-button--big.su-link:hover,
   .su-button--big.su-link:focus {
@@ -7799,6 +7804,15 @@ button,
   .su-button--big.su-link:focus {
     -webkit-box-shadow: 0 0 3px #4d4f53, 0 0 7px #4d4f53;
             box-shadow: 0 0 3px #4d4f53, 0 0 7px #4d4f53; }
+  @media only screen and (min-width: 768px) {
+    .su-button--big,
+    .su-button--big.su-link {
+      padding: 1.5rem 3rem 1.8rem;
+      font-size: 2.8rem; } }
+  @media only screen and (min-width: 1500px) {
+    .su-button--big,
+    .su-button--big.su-link {
+      font-size: 3rem; } }
 
 .su-button--secondary,
 .su-button--secondary.su-link {

--- a/core/src/scss/utilities/mixins/button/_button-big.scss
+++ b/core/src/scss/utilities/mixins/button/_button-big.scss
@@ -11,7 +11,15 @@
 
 @mixin button-big {
   @include button-primary;
+  @include padding(1.3rem 2.8rem 1.5rem);
+  font-size: 2.5rem;
 
-  @include type-c;
-  @include padding(1.5rem 3rem 1.8rem);
+  @include grid-media('md') {
+    @include padding(1.5rem 3rem 1.8rem);
+    font-size: 2.8rem;
+  }
+
+  @include grid-media('2xl') {
+    font-size: 3rem;
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The default `.su-button` uses `rem` for font size unit so I'm changing the `.su-button--big` to also use `rem` for font size instead of `em`. This ensures that the font size doesn't blow up when we increase a section's base font size (e.g., if one sets the hero region's base font size to use the splash font).
- Finetune the padding for `.su-button--big` at smaller breakpoints so it looks proportional.

# Needed By (Date)
- Whenever

# Urgency
- Not urgent

# Steps to Test

1. Pull this branch and compile styleguide
2. Look at the `.su-button--big` variant in component -> button and make sure that it looks proportional at all breakpoint. Check that it uses `rem` for font sizes instead of `em`.

# Affected Projects or Products
- Decanter
- Redwood

# Associated Issues and/or People
- @kerri-augenstein 