### PR TITLE
Global footer font-weight and spacing tweak

### DIFF
--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -8285,7 +8285,7 @@ button,
     display: block; }
     @media only screen and (min-width: 576px) and (max-width: 767px) {
       .su-global-footer__menu li {
-        margin-right: 1.1rem; } }
+        margin-right: 1rem; } }
     @media only screen and (min-width: 576px) {
       .su-global-footer__menu li {
         display: inline-block;
@@ -8303,7 +8303,7 @@ button,
 
 @media only screen and (min-width: 0) and (max-width: 575px) {
   .su-global-footer__menu--global {
-    padding-right: 2rem; } }
+    padding-right: 1.9rem; } }
 
 @media (min-width: 768px) and (max-width: 1499px) {
   .su-global-footer__menu--global {
@@ -8313,16 +8313,17 @@ button,
   .su-global-footer__menu--global {
     font-size: 1.8rem; } }
 
-.su-global-footer__menu--policy a {
-  font-weight: 400; }
-
 @media only screen and (min-width: 0) and (max-width: 575px) {
   .su-global-footer__menu--policy {
-    padding-left: 2rem; } }
+    padding-left: 1.9rem; } }
 
 @media only screen and (min-width: 576px) and (max-width: 767px) {
   .su-global-footer__menu--policy {
     font-size: 1.4rem; } }
+
+@media only screen and (min-width: 576px) {
+  .su-global-footer__menu--policy a {
+    font-weight: 400; } }
 
 @media (min-width: 768px) and (max-width: 1199px) {
   .su-global-footer__menu--policy {

--- a/core/src/scss/components/global-footer/_global-footer.scss
+++ b/core/src/scss/components/global-footer/_global-footer.scss
@@ -106,7 +106,7 @@
     display: block;
 
     @include grid-media-only('sm') {
-      @include margin(null 1.1rem null null);
+      @include margin(null 1rem null null);
     }
 
     @include grid-media('sm') {
@@ -132,7 +132,7 @@
 
 .su-global-footer__menu--global {
   @include grid-media-only('xs') {
-    @include padding(null 2rem null null);
+    @include padding(null 1.9rem null null);
   }
 
   @include grid-media-between('md', 'xl') {
@@ -145,16 +145,18 @@
 }
 
 .su-global-footer__menu--policy {
-  a {
-    font-weight: $su-font-regular;
-  }
-
   @include grid-media-only('xs') {
-    @include padding(null null null 2rem);
+    @include padding(null null null 1.9rem);
   }
 
   @include grid-media-only('sm') {
     font-size: 1.4rem;
+  }
+
+  @include grid-media('sm') {
+    a {
+      font-weight: $su-font-regular;
+    }
   }
 
   @include grid-media-between('md', 'lg') {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- At xs breakpoint, change the link list on the right column to have font-weight: 600 also to match Figma. Confirmed with JB this is what we prefer.
- Finetune font size and padding so things fit on one line and on PC.
- Perhaps this could go into 5.1.0?

# Needed By (Date)
- Sooner the better

# Urgency
- N/A

# Steps to Test

1. Look at the latest tugboat build.
2. Check that at xs breakpoint, both list of menu links have font-weight: 600. Check that spacing looks ok.

# Affected Projects or Products
- Decanter