### PR TITLE
Remove max-width on `flex-container`

### DIFF
--- a/core/dist/css/decanter-grid.css
+++ b/core/dist/css/decanter-grid.css
@@ -31,8 +31,7 @@ body {
       -ms-flex-pack: justify;
           justify-content: space-between;
   -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
-  max-width: 1500px; }
+      flex-wrap: wrap; }
   .flex-container--collapse {
     margin-top: 0;
     margin-bottom: 0; }

--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -687,8 +687,7 @@ textarea, select {
       -ms-flex-pack: justify;
           justify-content: space-between;
   -ms-flex-wrap: wrap;
-      flex-wrap: wrap;
-  max-width: 1500px; }
+      flex-wrap: wrap; }
   .flex-container--collapse {
     margin-top: 0;
     margin-bottom: 0; }
@@ -8735,7 +8734,6 @@ a {
             justify-content: space-between;
     -ms-flex-wrap: wrap;
         flex-wrap: wrap;
-    max-width: 1500px;
     -webkit-box-align: stretch;
         -ms-flex-align: stretch;
             align-items: stretch;
@@ -10046,7 +10044,6 @@ a {
             justify-content: space-between;
     -ms-flex-wrap: wrap;
         flex-wrap: wrap;
-    max-width: 1500px;
     margin: 0 auto; }
     @media only screen and (min-width: 0) {
       .su-masthead > section:last-of-type {

--- a/core/src/scss/utilities/mixins/flex/_flex-container.scss
+++ b/core/src/scss/utilities/mixins/flex/_flex-container.scss
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 
 //
-// @flex-container($gap: $gutter-xs)
+// @flex-container
 //
 // Mixin to apply to the wrapper of all class-based layouts.
 //
@@ -12,5 +12,4 @@
   flex-direction: row;
   justify-content: space-between;
   flex-wrap: wrap;
-  max-width: $su-site-max-width;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decanter",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- No need to max-width a container as we have other mixins and styles for limiting and positioning. 

Feedback:
> I was expecting flex-container to be full-width flex. and then I would add the centered-container to set max-width.

# Needed By (Date)
- Whenever

# Urgency
- Low

# Steps to Test

1. Review code changes
2. Review tugboat preview

# Associated Issues and/or People
- @pookmish 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
