### PR TITLE
Fix deprecated '@elseif' syntax

### DIFF
--- a/core/src/scss/utilities/mixins/animation/_fancy-hover.scss
+++ b/core/src/scss/utilities/mixins/animation/_fancy-hover.scss
@@ -70,7 +70,7 @@
       &::before {
         bottom: 0;
       }
-    } @elseif ($position == 'top') {
+    } @else if ($position == 'top') {
       @include padding(0.8em null null);
 
       &::before {
@@ -78,7 +78,7 @@
       }
     }
 
-  } @elseif ($position == 'left' or $position == 'right') {
+  } @else if ($position == 'left' or $position == 'right') {
     &::before {
       height: 100%;
       width: #{$thickness};
@@ -98,7 +98,7 @@
       &::before {
         left: 0;
       }
-    } @elseif ($position == 'right') {
+    } @else if ($position == 'right') {
       &::before {
         right: 0;
       }

--- a/core/src/scss/utilities/mixins/card/_card.scss
+++ b/core/src/scss/utilities/mixins/card/_card.scss
@@ -117,7 +117,7 @@
         }
       }
     }
-    @elseif ($image-hover == 'opacity') {
+    @else if ($image-hover == 'opacity') {
       .su-media__wrapper {
         img {
           transition: opacity 0.3s ease-in-out;

--- a/core/src/scss/utilities/mixins/link/_link-icon.scss
+++ b/core/src/scss/utilities/mixins/link/_link-icon.scss
@@ -33,13 +33,13 @@
         @if $animate == 'right' or $animate == 'true' {
           transform: translateX(0.2em);
         }
-        @elseif $animate == 'down' {
+        @else if $animate == 'down' {
           transform: translateY(0.2em);
         }
-        @elseif $animate == 'up' {
+        @else if $animate == 'up' {
           transform: translateY(-0.2em);
         }
-        @elseif $animate == 'topright' {
+        @else if $animate == 'topright' {
           transform: translate3d(0.15em, -0.15em, 0);
         }
       }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary

Fixes a few instances in Sass of `@elseif` syntax and replaces it with the support `@else if` syntax. Newer versions of Sass have deprecated the `@elseif` syntax and it will be dropped in future versions.

# Needed By (Date)

No specific date

# Urgency

Nothing is broken now. For those using the latest version of Sass, there are deprecation warning in every build which can cause lots of noise and make it hards to see other errors. The old syntax will probably continue to be supported for 6 months to a year or more.

# Steps to Test

1. Compile Decanter (before this commit) with the latest version of Dart Sass
1. You should see deprecation warnings
1. Compile this PR with the latest version of Dart Sass
1. The deprecation warnings should no longer be generated

# Affected Projects or Products

The H&S Drupal 8 project is currently getting these deprecation errors with new themes that are currently in development. This is because we are using the latest version of Dart Sass.

# Associated Issues and/or People

- SU-SWS/decanter#598
- @sherakama, @silverli 

# Accessibility Checks

- None, N/A


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
