### PR TITLE
Change @big-paragraph font size and line height

### DIFF
--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -3815,11 +3815,10 @@ button,
     .su-date-stacked {
       max-width: 105px; } }
   .su-date-stacked__month {
-    display: block;
-    font-size: 2.1rem; }
-    @media (max-width: 767px) {
+    display: block; }
+    @media only screen and (min-width: 768px) {
       .su-date-stacked__month {
-        font-size: 1.6rem; } }
+        font-size: 2.1rem; } }
   .su-date-stacked__day {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -3094,12 +3094,10 @@ dfn {
   font-size: 1.25em;
   font-style: italic; }
 
-.su-big-paragraph {
-  font-size: 2.1rem;
-  line-height: 1.7; }
-  @media (max-width: 767px) {
-    .su-big-paragraph {
-      font-size: 1.6rem; } }
+@media only screen and (min-width: 768px) {
+  .su-big-paragraph {
+    font-size: 2.1rem;
+    line-height: 1.7; } }
 
 .su-small-paragraph {
   font-size: 1.8rem;

--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -3095,7 +3095,8 @@ dfn {
   font-style: italic; }
 
 .su-big-paragraph {
-  font-size: 2rem; }
+  font-size: 2.1rem;
+  line-height: 1.7; }
   @media (max-width: 767px) {
     .su-big-paragraph {
       font-size: 1.6rem; } }
@@ -3815,13 +3816,13 @@ button,
   @media only screen and (min-width: 1500px) {
     .su-date-stacked {
       max-width: 105px; } }
-  .su-date-stacked .su-date-stacked__month {
-    font-size: 2rem;
-    display: block; }
+  .su-date-stacked__month {
+    display: block;
+    font-size: 2.1rem; }
     @media (max-width: 767px) {
-      .su-date-stacked .su-date-stacked__month {
+      .su-date-stacked__month {
         font-size: 1.6rem; } }
-  .su-date-stacked .su-date-stacked__day {
+  .su-date-stacked__day {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     margin-top: 0;
@@ -3831,11 +3832,11 @@ button,
     font-size: 1.953125em;
     letter-spacing: -0.016em;
     display: block; }
-    .su-date-stacked .su-date-stacked__day a {
+    .su-date-stacked__day a {
       text-decoration: none;
       font-weight: 700; }
     @media (max-width: 767px) {
-      .su-date-stacked .su-date-stacked__day {
+      .su-date-stacked__day {
         font-size: 1.66015625em; } }
 
 .su-date-stacked--no-background {

--- a/core/src/scss/components/date-stacked/_date-stacked.scss
+++ b/core/src/scss/components/date-stacked/_date-stacked.scss
@@ -26,12 +26,16 @@
     max-width: 105px;
   }
 
-  .su-date-stacked__month {
-    @include big-paragraph;
+  &__month {
     display: block;
+    font-size: 2.1rem;
+
+    @include grid-media-max('md') {
+      font-size: 1.6rem;
+    }
   }
 
-  .su-date-stacked__day {
+  &__day {
     @include types;
     @include type-b;
     display: block;

--- a/core/src/scss/components/date-stacked/_date-stacked.scss
+++ b/core/src/scss/components/date-stacked/_date-stacked.scss
@@ -28,10 +28,9 @@
 
   &__month {
     display: block;
-    font-size: 2.1rem;
 
-    @include grid-media-max('sm') {
-      font-size: 1.6rem;
+    @include grid-media('md') {
+      font-size: 2.1rem;
     }
   }
 

--- a/core/src/scss/components/date-stacked/_date-stacked.scss
+++ b/core/src/scss/components/date-stacked/_date-stacked.scss
@@ -30,7 +30,7 @@
     display: block;
     font-size: 2.1rem;
 
-    @include grid-media-max('md') {
+    @include grid-media-max('sm') {
       font-size: 1.6rem;
     }
   }

--- a/core/src/scss/utilities/mixins/typography/_big-paragraph.scss
+++ b/core/src/scss/utilities/mixins/typography/_big-paragraph.scss
@@ -8,10 +8,8 @@
 ///
 /// @group typography
 @mixin big-paragraph {
-  font-size: 2.1rem;
-  line-height: 1.7;
-
-  @include grid-media-max('sm') {
-    font-size: 1.6rem;
+  @include grid-media('md') {
+    font-size: 2.1rem;
+    line-height: 1.7;
   }
 }

--- a/core/src/scss/utilities/mixins/typography/_big-paragraph.scss
+++ b/core/src/scss/utilities/mixins/typography/_big-paragraph.scss
@@ -8,7 +8,8 @@
 ///
 /// @group typography
 @mixin big-paragraph {
-  font-size: 2rem;
+  font-size: 2.1rem;
+  line-height: 1.7;
 
   @include grid-media-max('sm') {
     font-size: 1.6rem;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Change @big-paragraph (and .su-big-paragraph) to have font size 2.1rem and 1.7 line height from MD breakpoint and up. 
- Previously the month portion of the date stacked component uses the @big-paragraph mixin. Changed it to not use the mixin since we don't want the 1.7 line height, but up the font size to 2.1rem (was 2rem previously since it uses the same font size as @big-paragraph).

# Needed By (Date)
- Sooner the better

# Urgency
- Sooner the better

# Steps to Test

1. Go to https://pr608-rwhkccdzw2clyyiuzswglwegda7ime8o.tugboat.qa/page/brand-design-elements-typography/
2. Scroll down to the Big Paragraph section near the bottom. Verify that .su-big-paragraph has 2.1rem font size and 1.7 line height from MD breakpoint and up (768px + ). Below that it's the same as regular body text which is 1.6rem and 1.4 line height.
3. Go to https://pr608-rwhkccdzw2clyyiuzswglwegda7ime8o.tugboat.qa/component/simple-date-stacked
4. Check that date stacked component font size looks good at all breakpoints.

# Affected Projects or Products
- Decanter
- D8

# Associated Issues and/or People
#607 
- @kerri-augenstein 