### PR TITLE
Change @type-f font size from 0.8em to 0.9em and remove uppercase style

### DIFF
--- a/core/dist/css/decanter.css
+++ b/core/dist/css/decanter.css
@@ -3016,8 +3016,7 @@ h5,
 
 h6,
 .su-type-f {
-  font-size: 0.8em;
-  text-transform: uppercase; }
+  font-size: 0.9em; }
 
 cite,
 var,
@@ -3401,8 +3400,7 @@ button,
       clear: both;
       font-weight: 700;
       line-height: 1.2;
-      font-size: 0.8em;
-      text-transform: uppercase;
+      font-size: 0.9em;
       display: block; }
       @media only screen and (min-width: 0) {
         .su-card .su-card__contents > span {

--- a/core/src/scss/utilities/mixins/typography/_type-f.scss
+++ b/core/src/scss/utilities/mixins/typography/_type-f.scss
@@ -7,6 +7,5 @@
 ///
 /// @group typography
 @mixin type-f {
-  @include modular-typography(-1);
-  text-transform: uppercase;
+  font-size: 0.9em;
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Change @type-f font size from 0.8em to 0.9em and remove uppercase style as requested by @kerri-augenstein 
- This will change the superheadline in the card and hero components.

# Needed By (Date)
- Sooner the better

# Urgency
- Sooner the better

# Steps to Test

1. Go to https://pr609-saoppsvp7getzi3bzr4irxrw1sqghbvo.tugboat.qa/page/brand-design-elements-typography/
2. See "Display Type F" section and check the font size and style is as requested.
3. Go to 
https://pr609-saoppsvp7getzi3bzr4irxrw1sqghbvo.tugboat.qa/component/composite-card/
https://pr609-saoppsvp7getzi3bzr4irxrw1sqghbvo.tugboat.qa/component/composite-hero/
4. Check that the superheadline in the card and hero components style is as requested.

# Affected Projects or Products
- D8
- Decanter

# Associated Issues and/or People
- #603 
- @kerri-augenstein 