### PR TITLE
D8CORE-713: Brand bar wrapper change.

### DIFF
--- a/core/src/templates/components/brand-bar/brand-bar.twig
+++ b/core/src/templates/components/brand-bar/brand-bar.twig
@@ -14,6 +14,6 @@
  * - modifier_class: Additional css classes to change look and behaviour.
  */
 #}
-<section class="su-brand-bar {{ modifier_class }}">
+<div class="su-brand-bar {{ modifier_class }}">
   <div class="su-brand-bar__container"><a {{ attributes }} class="su-brand-bar__logo" href="https://stanford.edu">Stanford University</a></div>
-</section>
+</div>


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Changes semantics based on the recommendation from level acess

```
See https://validator.w3.org/nu/?doc=https%3A%2F%2Famptesting.sites.stanford.edu%2F

Warning: Section lacks heading. Consider using h2-h6 elements to add identifying headings to all sections.

From line 55, column 5; to line 55, column 35

</a>↩ <section class="su-brand-bar ">↩ <di

The validator wants a heading for each <section>, including the brand-bar!

https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines:

The section element is use for a thematic grouping of content. Based on the W3C spec, a section should typically contain a heading. The heading does not require the use of the <header> element
```

# Revew By (Date)
- Whenever

# Urgency
- Low

# Steps to Test

1. Review code
2. Build and review styles

# Affected Projects or Products
- Everything

# Associated Issues and/or People
- D8 CORE

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
