### PR TITLE
feat: add calculate-font-size function

### DIFF
--- a/core/src/scss/components/alert/_alert.scss
+++ b/core/src/scss/components/alert/_alert.scss
@@ -17,36 +17,36 @@
 // Style guide: Simple.Alert
 //
 .su-alert {
-  @include padding(2rem);
+  @include padding(calculate-font-size(20px));
   background-color: color(default, $su-alert-colors);
-  background-position: 1rem center;
+  background-position: calculate-font-size(10px) center;
   background-repeat: no-repeat;
-  background-size: 4rem;
+  background-size: calculate-font-size(40px);
   color: color(dark-text, $su-alert-colors);
 
   @include grid-media('md') {
-    background-size: 5.2rem;
+    background-size: calculate-font-size(52px);
   }
 
   .su-alert__body {
     display: table-cell;
     vertical-align: top;
 
-    @include padding(null null null 3.5rem);
+    @include padding(null null null calculate-font-size(35px));
 
     @include grid-media('md') {
-      @include padding(null null null 5rem);
+      @include padding(null null null calculate-font-size(50px));
     }
 
     p:last-child {
-      @include margin(null null 0.8rem);
+      @include margin(null null calculate-font-size(8px));
     }
 
     .su-alert__heading {
-      @include margin(0 null 0.3rem);
+      @include margin(0 null calculate-font-size(3px));
 
       @include grid-media('md') {
-        @include margin(0.3rem null null);
+        @include margin(calculate-font-size(3px) null null);
       }
     }
 

--- a/core/src/scss/utilities/functions/_fonts.scss
+++ b/core/src/scss/utilities/functions/_fonts.scss
@@ -1,0 +1,15 @@
+@charset "UTF-8";
+
+///
+/// Calculate font-size to use rems based upon 
+/// the root font size ($su-root-font-size) 
+/// set in core/src/scss/utilities/variables/core/_typography.scss
+///
+/// @name calculate-font-size
+///
+/// @param {String} $size-in-pixels - The value to be converted from pixels to rems.
+
+@function calculate-font-size($size-in-pixels) {
+  $font-size: $size-in-pixels / $su-root-font-size;
+  @return #{$font-size}rem;
+}

--- a/core/src/scss/utilities/functions/index.scss
+++ b/core/src/scss/utilities/functions/index.scss
@@ -8,6 +8,7 @@
 'breakpoint/index',
 'color',
 'flex/index',
+'fonts',
 'modular-scale/index',
 'string/index',
 'type-checks/index';

--- a/core/src/scss/utilities/variables/core/_typography.scss
+++ b/core/src/scss/utilities/variables/core/_typography.scss
@@ -12,7 +12,7 @@
 /// @name $su-root-font-size
 ///
 /// @group variable
-$su-root-font-size: 62.5%;
+$su-root-font-size: 10px;
 
 ///
 /// Font size.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
We would like to use Decanter sass styles and HTML for the immense time and effort it will save us, and for the branded consistency it provides, especially in places like the Brand bar, navigation, footer, and lockups.

Currently, we have our own SCSS styles set with a base font-size set on the html element of 16px. When trying to use Decanter for our main navigation styles, we realized that the Decanter base font-size is set to 62.5%, or what comes out to 10px in those styles.

I think we are open to using 10px as the base font size for our styles if it is necessary, or if the Decanter team has a reason they prefer that base font-size, and we could then adjust our own styles and where we use rem values currently. However, I did want to mention that 16px as a base font-size is quite standard across the internet and different browsers, and this compelling article also has SEO reasons listed for keeping it 16px as well: https://www.mediavine.com/increase-font-size-and-increase-seo-rpm-along-with-it/

I did see that the `$su-root-font-size` is a variable that can be adjusted, which I was excited about https://github.com/SU-SWS/decanter/blob/master/core/src/scss/elements/typography/_typography.scss#L29:L32 ! However, if I adjust the `$su-root-font-size` variable to 16px, then because rems were used in Decanter styles based on the assumption that base font size was 10px, everything on our site using Decanter styles becomes huge.

For example, the Decanter style for the main navigation li a font-size is set to 2.1rems, which is 21px on your site, but becomes 33.6px on our site.

I was hoping that the Decanter design system might be a bit more flexible, and build in some ways that base font-size could be set alternatively, to accommodate for the different ways projects might write their styles.
 
## A potential alternative solution
My coworker Heather and I had one idea we wanted to run by you that could allow rems to continue to be used in both Decanter as they are now, and in our styles as well (as we understand rems are very accessible for websites to resize text).

We came up with a `calculate-font-size` function that could be used in Decanter such that your team could continue using 10px as a base font-size, but it would not drastically impact styles on another site that might not use that as the base font size, but maybe used 16px, or 18px, etc.

Please take a look at the files changed in this PR to see the function, some comments about the function, and it's potential implementation in one place in the Decanter code base. If you are happy with the solution, we can make the changes everywhere, but we didn't want to do that without chatting with you first!

We also made a Codepen if you'd rather play around with the function we made in that environment instead! https://codepen.io/silverli/pen/rNVOajq?editors=1100 

## Expected Behavior
We were hoping for a bit more flexibility with Decanter for setting CSS values, including using a different base html font-size than 10px.

# Needed By (Date)
No specific date

# Urgency
We are working on brand-bar, footer, and navigation elements this week, so we would like to know a best way forward for now, or what solution might align with your goals.

# Steps to Test
Steps to reproduce the behavior:
Try switching `$su-root-font-size` to 16px and see that styles across Decanter look very large.

# Affected Projects or Products
The H&S Drupal 8 project is currently seeing a very large main navigation when we pull in the Decanter styles. This is because our base-font size and rem values we use don't align with Decanter's.

# Associated Issues and/or People
[@silverli](https://github.com/silverli), [@heatherdesigns](https://github.com/heatherdesigns)

