### PR TITLE
Add aria-expanded="false" to main nav parent links in the twig template

### DIFF
--- a/core/src/templates/components/main-nav/main-nav.twig
+++ b/core/src/templates/components/main-nav/main-nav.twig
@@ -36,7 +36,7 @@
                 {% set the_attrs = the_attrs ~ ' ' ~ pair.attr ~ '="' ~ pair.value ~ '"' %}
               {% endfor -%}
             {% endif -%}
-            <a href="{{ item.href }}" {{ the_attrs }}>{{ item.text }}</a>
+            <a href="{{ item.href }}" {{ the_attrs }} {% if is_parent %}aria-expanded="false"{% endif %}>{{ item.text }}</a>
             {%- if is_parent -%}
               <ul class="su-main-nav__menu-lv2">
                 {%- for item_lv2 in item.lv2 -%}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decanter",
-  "version": "6.0.4",
+  "version": "6.0.6-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Had a consulting session with Level Access. They suggested adding `aria-expanded="false"` to parent links (the ones that you click to trigger a drop down menu to open) in our Main Nav on load. Currently, the `aria-expanded` attribute is added only after a parent link has been clicked on.

# Needed By (Date)
- N/A

# Urgency
- Not urgent but sooner the better

# Steps to Test
- Not sure what's the best way to test since tugboat is over quota. I did the same modification in UComm's Redwood WP template and this change works while keeping all current JS working as expected. Might want to make sure this doesn't break anything on the Drupal side (should be fairly low risk but just in case).

# Affected Projects or Products
- Decanter
- Redwood, UComm sites

# Associated Issues and/or People
- #680 