### PR TITLE
Make it possible for the site search input field to have different values for "name" and ID

### DIFF
--- a/core/src/templates/components/site-search/site-search.twig
+++ b/core/src/templates/components/site-search/site-search.twig
@@ -11,7 +11,8 @@
  * - action: Action of the form
  * - method: Method of the form
  * - search_label: Custom screen reader label
- * - search_input_name: Name for the search input field. Also used as the ID of the search input field and the "for" attribute of the label.
+ * - search_input_name: Name for the search input field. Also used as the "for" attribute of the search input field label.
+ * - search_input_id: ID for the search input field. If not provided, it will take on the same value as search_input_name.
  * - search_input_attributes: Additional HTML attributes for the search input field
  * - placeholder: Placeholder text for the search input field
  * - search_button_attributes: Additional HTML attributes for the submit button
@@ -21,10 +22,13 @@
  *
  */
 #}
+{%- if search_input_id is empty -%}
+  {%- set search_input_id = search_input_name -%}
+{%- endif -%}
 <div {{ attributes }} class="su-site-search {{ modifier_class }}" role="search">
  <form action="{{ action }}" method="{{ method }}" accept-charset="UTF-8">
   <label class="su-site-search__sr-label" for="{{ search_input_name|default('search-field') }}">{{ search_label|default('Search this site') }}</label>
-  <input {{ search_input_attributes }} type="text" id="{{ search_input_name|default('search-field') }}" name="{{ search_input_name|default('search-field') }}" class="su-site-search__input" placeholder="{{ placeholder|default('Search this site') }}" maxlength="128">
+  <input {{ search_input_attributes }} type="text" id="{{ search_input_id|default('search-field') }}" name="{{ search_input_name|default('search-field') }}" class="su-site-search__input" placeholder="{{ placeholder|default('Search this site') }}" maxlength="128">
   <button {{ search_button_attributes }} type="submit" name="{{ search_button_name|default('search') }}" class="su-site-search__submit su-sr-only-text" aria-label="Search">{{ search_button_text|default('Submit Search') }}</button>
   {#- Any additional eg. hidden input fields -#}
   {{- additional_fields -}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decanter",
-  "version": "6.0.6-dev",
+  "version": "6.0.7-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Currently, in the site search component search input field, the "name" attribute and ID are forced to take on the same value (variable `search_input_name`), but on some sites when there are multiple instances of the search form, sometimes we need 2 forms with the same "name" for the input fields but different IDs.
- This PR adds the option to add a different ID `search_input_id` when needed. If that's not provided, it will be the same as the value for "name"
- Note: There might be a different approach to this - do we need the search input field to have an ID at all? If not, perhaps we can remove it and just add an additional_input_attribute variable in the next Decanter version.

# Needed By (Date)
- Sooner the better

# Urgency
- N/A

# Steps to Test

1. Copy the content of site-search.twig and paste the content into a test.twig (needs to create this file) file in the developer folder and follow the README there to set up the preview environment.
1. Add test.json file in the developer directory with different search_input_name and search_input_id values.
1. Do npm run dev and npm run start. Look at the site search component on the rendered page in the inspector and verify that the ID and name for the search input field are different.

# Affected Projects or Products
- Decanter
- D8
- Redwood

# Associated Issues and/or People
- #686 