### PR TITLE
D8CORE-2376: Allow override of lockup in local footer

### DIFF
--- a/core/src/templates/components/local-footer/local-footer.twig
+++ b/core/src/templates/components/local-footer/local-footer.twig
@@ -83,7 +83,9 @@
   {% if lockup_title is not empty or weblogin_url is not empty or headercontent is not empty %}
   <div class="su-local-footer__header">
     {# Lockup template. Set usually to option-a #}
-    {% include template_path_lockup with lockup_options %}
+    {% block block_lockup %}
+      {% include template_path_lockup with lockup_options %}
+    {% endblock %}
     {# Web login button #}
     {% if weblogin_url is not empty %}
       {% include template_path_link with {


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Wraps the include statement for the lockup in a block so it can be overridden in parent templates.

# Needed By (Date)
- Sept 3rd

# Urgency
- High

# Steps to Test

1. Review code
2. Leave comments

# Affected Projects or Products
- D8CORE-2376

# Associated Issues and/or People
- D8CORE-2376

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
