### PR TITLE
D8CORE-2529: if there is a link but no content set the link to null

### DIFF
--- a/core/src/templates/components/media/media.twig
+++ b/core/src/templates/components/media/media.twig
@@ -28,10 +28,11 @@
  * - media_caption: Optional caption for the media.
  */
 #}
+
 {# Set link to null if there is no content to prevent an empty link #}
-  {% if media_link is not empty and media_image_src is empty and media_audio_src is empty and media_video_src is empty %}
-    {% set media_link = false %}
-  {% endif -%}
+{%- if media_link is not empty and media_image_src is empty and media_audio_src is empty and media_video_src is empty -%}
+  {%- set media_link = false -%}
+{%- endif -%}
 
 <figure {{ attributes }} class="su-media {{ modifier_class }}">
   {# Option to make the media element a clickable link #}

--- a/core/src/templates/components/media/media.twig
+++ b/core/src/templates/components/media/media.twig
@@ -28,9 +28,13 @@
  * - media_caption: Optional caption for the media.
  */
 #}
+
 <figure {{ attributes }} class="su-media {{ modifier_class }}">
   {# Option to make the media element a clickable link #}
-  {%- if media_link %}
+  {# Set link to null if there is no content to prevent an empty link #}
+  {% if media_link is not empty and media_image_src is empty and media_audio_src is empty and media_video_src is empty %}
+    {% set media_link = null %}
+  {%- elseif media_link %}
     <a {{ media_link_attributes }} href="{{ media_link }}">
   {% endif -%}
 

--- a/core/src/templates/components/media/media.twig
+++ b/core/src/templates/components/media/media.twig
@@ -28,13 +28,14 @@
  * - media_caption: Optional caption for the media.
  */
 #}
+{# Set link to null if there is no content to prevent an empty link #}
+  {% if media_link is not empty and media_image_src is empty and media_audio_src is empty and media_video_src is empty %}
+    {% set media_link = false %}
+  {% endif -%}
 
 <figure {{ attributes }} class="su-media {{ modifier_class }}">
   {# Option to make the media element a clickable link #}
-  {# Set link to null if there is no content to prevent an empty link #}
-  {% if media_link is not empty and media_image_src is empty and media_audio_src is empty and media_video_src is empty %}
-    {% set media_link = null %}
-  {%- elseif media_link %}
+  {%- if media_link %}
     <a {{ media_link_attributes }} href="{{ media_link }}">
   {% endif -%}
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove the link when there is no content but a link is added.

# Needed By (Date)
- 9/24

# Urgency
- medium

# Steps to Test

1. Pull in this change
2. Test in the developer directory.
3. Try removing all the json except the link.
4. Verify there is no empty link 
5. Try undoing it and test with the link and content.
6. Verify there is a link around the content. 

# Affected Projects or Products
- Decanter, SoE, Basic
- Sites that use the media module.

# Associated Issues and/or People
- D8CORE-2529
- @cjwest 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
