### PR TITLE
D8CORE-2151: Remove empty html

### DIFF
--- a/core/src/templates/components/card/card.twig
+++ b/core/src/templates/components/card/card.twig
@@ -62,6 +62,16 @@
   {%- endif -%}
 {%- endif -%}
 
+{# For variant where there's no card contents #}
+{% set card_contents_not_empty = false %}
+{% if card_super_headline is not empty or
+  card_headline is not empty or
+  card_body is not empty or
+  card_cta_label is not empty or
+  card_button_label is not empty %}
+  {% set card_contents_not_empty = true %}
+{% endif %}
+
 <article {{ attributes }} class="su-card {{ modifier_class }}">
   {# For variant where whole card is a link, add an <a> within the outer wrapper <div> #}
   {%- if allow_links == false %}
@@ -133,13 +143,14 @@
     {% endif %}
   {% endblock block_card_media -%}
 
-  <section class="su-card__contents">
+  {%- if card_contents_not_empty -%}
+  <div class="su-card__contents cjw">
     {# Card Super Headline #}
-    {%- block block_card_super_headline %}
-      {% if card_super_headline is not empty %}
+    {% if card_super_headline is not empty %}
+      {%- block block_card_super_headline %}
         <span>{{ card_super_headline }}</span>
-      {% endif -%}
-    {% endblock -%}
+      {% endblock -%}
+    {% endif -%}
 
     {# Card Headline #}
     {%- block block_card_headline  %}
@@ -153,13 +164,16 @@
             </a>
           {%- endif -%}
         </h2>
+        
       {% endif -%}
     {% endblock -%}
 
-    {%- block block_card_body %}
-      {# An open field for body content #}
-      {{ card_body }}
-    {% endblock -%}
+    {# An open field for body content #}
+    {% if card_body is not empty %}
+      {%- block block_card_body %}
+        {{ card_body }}
+      {% endblock -%}
+    {% endif -%}
 
     {# Block for CTA elements, e.g., link, button #}
     {%- block block_card_cta %}
@@ -191,7 +205,8 @@
         </div>
       {% endif -%}
     {% endblock -%}
-  </section>{# end of .su-card__contents #}
+  </div>{# end of .su-card__contents #}
+  {% endif -%}{# end of card_contents_not_empty #}
   {%- if allow_links == false %}
     </a>
   {%- endif -%}


### PR DESCRIPTION
# Not READY FOR REVIEW


# Summary
This removes unneeded HTML in the card when there's no content.
This removes the `<section>` tag that wasn't quite appropriate.

# Needed By (Date)
- 

# Urgency
Not urgent

# Steps to Test

1. check out this branch
2. Create a card with only the required content.
3. Verify that there's no additional HTML


# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?
D8Core

# Associated Issues and/or People
- JIRA ticket - [D8CORE-2151]( https://stanfordits.atlassian.net/browse/D8CORE-2151)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
