### PR TITLE
D8CORE-2529: changing the condition that makes the link not appear

### DIFF
--- a/core/src/templates/components/media/media.twig
+++ b/core/src/templates/components/media/media.twig
@@ -29,11 +29,6 @@
  */
 #}
 
-{# Set link to null if there is no content to prevent an empty link #}
-{%- if media_image_src is empty and media_audio_src is empty and media_video_src is empty -%}
-  {%- set media_link = false -%}
-{%- endif -%}
-
 <figure {{ attributes }} class="su-media {{ modifier_class }}">
   {# Option to make the media element a clickable link #}
   {%- if media_link %}

--- a/core/src/templates/components/media/media.twig
+++ b/core/src/templates/components/media/media.twig
@@ -30,7 +30,7 @@
 #}
 
 {# Set link to null if there is no content to prevent an empty link #}
-{%- if media_link is not empty and media_image_src is empty and media_audio_src is empty and media_video_src is empty -%}
+{%- if media_image_src is empty and media_audio_src is empty and media_video_src is empty -%}
   {%- set media_link = false -%}
 {%- endif -%}
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This is a change to the way the link is made null. It should be added so this request can happen: https://github.com/SU-SWS/jumpstart_ui/pull/82. As it is currently, the link is always null, so I changed it to be only null if the media is null.  

# Needed By (Date)
- 12/2

# Urgency
- high

# Steps to Test

1. pull in this change. 
2. Verify the media works with image and link, image and no link. If there is a link and no images then the link doesn't appear.
3. I'm not sure how to test out this change with the other change https://github.com/SU-SWS/jumpstart_ui/pull/82 change
4. Need guidance here. :) 

# Affected Projects or Products
- Decanter
- JumpstartUI and https://github.com/SU-SWS/jumpstart_ui/pull/82

# Associated Issues and/or People
- D8CORE-2529
- https://github.com/SU-SWS/jumpstart_ui/pull/82
- D8CORE-2105
- @sherakama @pookmish 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
