### PR TITLE
ADAPT-2435 Add text-shadow TailwindCSS utility

### DIFF
--- a/dist/decanter-components.css
+++ b/dist/decanter-components.css
@@ -3582,6 +3582,18 @@
   margin-top: 1em;
 }
 
+.su-text-shadow{
+  text-shadow: rgba(0, 0, 0, 40%) 0 0 6px, rgba(0, 0, 0, 60%) 0 0 2px;
+}
+
+.su-text-shadow-md{
+  text-shadow: rgba(0, 0, 0, 40%) 0 0 8px, rgba(0, 0, 0, 60%) 0 0 3px;
+}
+
+.su-text-shadow-lg{
+  text-shadow: rgba(0, 0, 0, 30%) 0 0 12px;
+}
+
 .su-aspect-w-1,
 .su-aspect-w-2,
 .su-aspect-w-3,

--- a/src/plugins/components/shadow/text-shadow.js
+++ b/src/plugins/components/shadow/text-shadow.js
@@ -1,0 +1,20 @@
+/**
+ * Text shadow styles
+ */
+ module.exports = function () {
+  return function ({ addComponents }) {
+    const components = {
+      '.text-shadow': {
+        textShadow: 'rgba(0, 0, 0, 40%) 0 0 6px, rgba(0, 0, 0, 60%) 0 0 2px'
+      },
+      '.text-shadow-md': {
+        textShadow: 'rgba(0, 0, 0, 40%) 0 0 8px, rgba(0, 0, 0, 60%) 0 0 3px'
+      },
+      '.text-shadow-lg': {
+        textShadow: 'rgba(0, 0, 0, 30%) 0 0 12px'
+      },
+    }
+
+    addComponents(components)
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,6 +76,7 @@ module.exports = {
     require(dir + '/components/typography/modular-typography.js')(),
     require(dir + '/components/typography/styles.js')(),
     require(dir + '/components/typography/wysiwyg.js')(),
+    require(dir + '/components/shadow/text-shadow.js')(),
 
     // @tailwind utilities;
     require(dir + '/utilities/accessibility/accessibility-hidden.js')(),


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add text-shadow TailwindCSS utility

# Needed By (Date)
- 05/07

# Urgency
- low

# Steps to Test
1. Pull this PR
2. Set up `dev`
3. Add `su-text-shadow-lg` class to heading within `test.html`
4. Start up local dev and inspect heading

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
