### PR TITLE
D8CORE-4728: removed offending aria-label

### DIFF
--- a/core/src/templates/components/site-search/site-search.twig
+++ b/core/src/templates/components/site-search/site-search.twig
@@ -29,7 +29,7 @@
  <form action="{{ action }}" method="{{ method }}" accept-charset="UTF-8">
   <label class="su-site-search__sr-label" for="{{ search_input_name|default('search-field') }}">{{ search_label|default('Search this site') }}</label>
   <input {{ search_input_attributes }} type="text" id="{{ search_input_id|default('search-field') }}" name="{{ search_input_name|default('search-field') }}" class="su-site-search__input" placeholder="{{ placeholder|default('Search this site') }}" maxlength="128">
-  <button {{ search_button_attributes }} type="submit" name="{{ search_button_name|default('search') }}" class="su-site-search__submit su-sr-only-text" aria-label="Search">{{ search_button_text|default('Submit Search') }}</button>
+  <button {{ search_button_attributes }} type="submit" name="{{ search_button_name|default('search') }}" class="su-site-search__submit su-sr-only-text">{{ search_button_text|default('Submit Search') }}</button>
   {#- Any additional eg. hidden input fields -#}
   {{- additional_fields -}}
  </form>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Currently the search is broken for voice navigation because the visible label and accessible name do not match. 
See https://my2.siteimprove.com/Accessibility/1061997/NextGen/Issue?ruleId=14&pageSegments=&issueKind=1&exceptTags=1,2&conformance=&siteGoal=0,1,3,4

# Needed By (Date)
Soon

# Urgency
- Broken on all sites. This stops people from using search with voice navigation. See comment in ticket: 
https://stanfordits.atlassian.net/browse/D8CORE-4728?focusedCommentId=122125
- SODA has called it out again.

# Steps to Test

1. Pull this into your site
2. Verify in the search form that the `aria-label="Search"` has been removed.



# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?
- D9Core
- Anything with V6

# Associated Issues and/or People
- JIRA ticket: https://stanfordits.atlassian.net/browse/D8CORE-4728 
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
