### PR TITLE
SDSS-234: Removal of title on non interactive element for a11y

### DIFF
--- a/core/src/templates/components/global-footer/global-footer.twig
+++ b/core/src/templates/components/global-footer/global-footer.twig
@@ -18,7 +18,7 @@
 {%- endif %}
 
 <div class="su-global-footer {{ modifier_class }}">
-  <div class="su-global-footer__container" title="Common Stanford resources">
+  <div class="su-global-footer__container">
     <div class="su-global-footer__brand">
       {%- include template_path_logo -%}
     </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed the title on a non interactive div element. This was for a11y compliance.

# Needed By (Date)
- 3/1

# Urgency
- Normal

# Steps to Test

1. Pull in the change. 
2. Notice there the title is removed from the footer div with all the links.

# Affected Projects or Products
- Sites using v6 of Decanter

# Associated Issues and/or People
[- SDSS-234](https://stanfordits.atlassian.net/browse/SDSS-234)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
