### PR TITLE
D8CORE-5738 | @jdwjdwjdw | Update global footer for A11y

### DIFF
--- a/core/src/templates/components/brand-bar/brand-bar.twig
+++ b/core/src/templates/components/brand-bar/brand-bar.twig
@@ -16,7 +16,7 @@
 #}
 {% if external_link_text is empty -%}
   {%- set external_link_text -%}
-    <span class="su-brand-bar__link--a11y">(link is external)</span>
+    <span class="su-brand-bar__link--a11y"> (link is external)</span>
   {% endset %}
 {%- endif %}
 

--- a/core/src/templates/components/global-footer/global-footer.twig
+++ b/core/src/templates/components/global-footer/global-footer.twig
@@ -13,7 +13,7 @@
 {%- endif %}
 {% if external_link_text is empty -%}
   {%- set external_link_text -%}
-    <span class="su-global-footer__link-a11y">(link is external)</span>
+    <span class="su-global-footer__link-a11y"> (link is external)</span>
   {% endset %}
 {%- endif %}
 
@@ -25,7 +25,7 @@
     <div class="su-global-footer__content">
       <nav aria-label="global footer menu">
         <ul class="su-global-footer__menu su-global-footer__menu--global">
-          <li><a href="https://www.stanford.edu">Stanford Home{{ external_link_text }}</a></li>
+          <li><a href="https://www.stanford.edu" aria-describedby="su-logo">Stanford Home{{ external_link_text }}</a></li>
           <li><a href="https://visit.stanford.edu/plan/">Maps &amp; Directions{{ external_link_text }}</a></li>
           <li><a href="https://www.stanford.edu/search/">Search Stanford{{ external_link_text }}</a></li>
           <li><a href="https://emergency.stanford.edu">Emergency Info{{ external_link_text }}</a></li>

--- a/core/src/templates/components/global-footer/global-footer.twig
+++ b/core/src/templates/components/global-footer/global-footer.twig
@@ -26,7 +26,7 @@
       <nav aria-label="global footer menu">
         <ul class="su-global-footer__menu su-global-footer__menu--global">
           <li><a href="https://www.stanford.edu" aria-describedby="su-logo">Stanford Home{{ external_link_text }}</a></li>
-          <li><a href="https://visit.stanford.edu/plan/">Maps &amp; Directions{{ external_link_text }}</a></li>
+          <li><a href="https://visit.stanford.edu/basics/">Maps &amp; Directions{{ external_link_text }}</a></li>
           <li><a href="https://www.stanford.edu/search/">Search Stanford{{ external_link_text }}</a></li>
           <li><a href="https://emergency.stanford.edu">Emergency Info{{ external_link_text }}</a></li>
         </ul>

--- a/core/src/templates/components/logo/logo.twig
+++ b/core/src/templates/components/logo/logo.twig
@@ -12,4 +12,10 @@
  * - logo_text: The text for the ligature logo - either Stanford<br>University or Stanford.
  */
 #}
-<a {{ attributes }} class="su-logo {{ modifier_class }}" href="{{ href|default('https://www.stanford.edu') }}">{{ logo_text|default('Stanford<br>University')|raw }}</a>
+{% if external_link_text is empty -%}
+  {%- set external_link_text -%}
+    <span class="su-global-footer__link-a11y"> (link is external)</span>
+  {% endset %}
+{%- endif %}
+
+<a {{ attributes }} id="su-logo" class="su-logo {{ modifier_class }}" href="{{ href|default('https://www.stanford.edu') }}">{{ logo_text|default('Stanford<br>University')|raw }}{{ external_link_text }}</a>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Global footer a11y updates. I am currently blocked in terms of being able to test these changes on my local, so additional work / changes will probably be needed. Please keep me updated on any issues that come up as you review.
- [D8CORE-2730](https://stanfordits.atlassian.net/browse/D8CORE-2730): A11y: in the global footer add "Link is external" for AT to logo
- [D8CORE-5738](https://stanfordits.atlassian.net/browse/D8CORE-5738): A11y | Decanter Global Footer: Links have different text and go to the same place
- [D8CORE-5798](https://stanfordits.atlassian.net/browse/D8CORE-5798): A11y: in the global footer the "Link is external" needs spacing
- [D8CORE-6654](https://stanfordits.atlassian.net/browse/D8CORE-6654): Update links in Global Footer
  - Maps & Directions link updated to https://visit.stanford.edu/basics/
- I also added a space before the (link is external) in the brand bar.

# Needed By (Date)
- When convenient

# Urgency
- Normal

# Steps to Test

1. Checkout branch
2. Review and inspect the global footer on a site
3. [D8CORE-2730](https://stanfordits.atlassian.net/browse/D8CORE-2730): confirm that ` link is external` text has been added to the Logo
4. [D8CORE-5738](https://stanfordits.atlassian.net/browse/D8CORE-5738): confirm that an `aria-describedby` and `id` has been added to connect the two links that go to the same place (The Stanford logo, and the `Stanford Home` link, and that WAVE no longer flags it as a redundant link
5. [D8CORE-5798](https://stanfordits.atlassian.net/browse/D8CORE-5798): confirm that the `link is external` span includes a space at the beginning. I'm not sure if just adding a space is fine, or if we need to add `&nbsp;` - I'm unable to test this work out currently, so let me know if that span is not showing a space

# Associated Issues and/or People
- [D8CORE-2730](https://stanfordits.atlassian.net/browse/D8CORE-2730): A11y: in the global footer add "Link is external" for AT to logo
- [D8CORE-5738](https://stanfordits.atlassian.net/browse/D8CORE-5738): A11y | Decanter Global Footer: Links have different text and go to the same place
- [D8CORE-5798](https://stanfordits.atlassian.net/browse/D8CORE-5798): A11y: in the global footer the "Link is external" needs spacing


[D8CORE-2730]: https://stanfordits.atlassian.net/browse/D8CORE-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-5738]: https://stanfordits.atlassian.net/browse/D8CORE-5738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-5798]: https://stanfordits.atlassian.net/browse/D8CORE-5798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-2730]: https://stanfordits.atlassian.net/browse/D8CORE-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-5738]: https://stanfordits.atlassian.net/browse/D8CORE-5738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[D8CORE-6654]: https://stanfordits.atlassian.net/browse/D8CORE-6654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ