### PR TITLE
Change centered-container to use max width and allow nesting of classes

### DIFF
--- a/src/plugins/components/layout/centered-container.js
+++ b/src/plugins/components/layout/centered-container.js
@@ -2,7 +2,7 @@
  * Centered container.
  */
 module.exports = function () {
-  return function ({ addUtilities, theme }) {
+  return function ({ addComponents, theme }) {
     // Find and set the padding based on the screen margins
     const screens = theme('screens');
     const maxWdiths = {};
@@ -42,6 +42,6 @@ module.exports = function () {
       },
     };
 
-    addUtilities(components);
+    addComponents(components);
   };
 };

--- a/src/plugins/components/layout/centered-container.js
+++ b/src/plugins/components/layout/centered-container.js
@@ -30,7 +30,7 @@ module.exports = function () {
     const key = `@media only screen and (min-width: ${largestScreen + (largestGutter * 2)}px)`
     const components = {
       // Center an element horizontally.
-      '.centered': {
+      '.centered-container, .cc': {
         maxWidth: 'calc(100vw - ' + (smallestGutter * 2) + 'px)',
         width: '100%',
         marginLeft: 'auto',

--- a/src/plugins/components/layout/centered-container.js
+++ b/src/plugins/components/layout/centered-container.js
@@ -2,36 +2,38 @@
  * Centered container.
  */
 module.exports = function () {
-  return function ({ addComponents, theme }) {
+  return function ({ addUtilities, theme }) {
     // Find and set the padding based on the screen margins
     const screens = theme('screens');
-    const padding = {};
+    const maxWdiths = {};
 
-    // Create padding for each screen size which equals to the screen margin setting.
+    // Create max widths for each screen size which equals to the screen margin
+    // setting.
     const keys = Object.keys(screens);
     keys.forEach((key) => {
-      padding[`@screen ${key}`] = {
-        paddingLeft: theme(`decanter.screenMargins.${key}`),
-        paddingRight: theme(`decanter.screenMargins.${key}`),
-      };
+      if (theme(`decanter.screenMargins.${key}`)) {
+        const gutterWidth = parseInt(theme(`decanter.screenMargins.${key}`));
+
+        maxWdiths[`@screen ${key}`] = {
+          maxWidth: 'calc(100vw - ' + (gutterWidth * 2) + 'px)',
+        };
+      }
     });
 
     const components = {
       // Center an element horizontally.
       '.centered-container, .cc': {
-        paddingLeft: theme('decanter.screenMargins.xs'),
-        paddingRight: theme('decanter.screenMargins.xs'),
+        maxWidth: 'calc(100vw - ' + (parseInt(theme(`decanter.screenMargins.xs`)) * 2) + 'px)',
+        width: '100%',
         marginLeft: 'auto',
         marginRight: 'auto',
-        ...padding,
-        // At 1700px (2xl breakpoint + twice the screen margins at 2xl), the max container width stays at 1500px.
+        ...maxWdiths,
         '@media only screen and (min-width: 1700px)': {
-          paddingLeft: 'calc((100% - 1500px)/2)',
-          paddingRight: 'calc((100% - 1500px)/2)',
+          maxWidth: '1500px'
         },
       },
     };
 
-    addComponents(components);
+    addUtilities(components);
   };
 };

--- a/src/plugins/components/layout/centered-container.js
+++ b/src/plugins/components/layout/centered-container.js
@@ -6,30 +6,38 @@ module.exports = function () {
     // Find and set the padding based on the screen margins
     const screens = theme('screens');
     const maxWdiths = {};
+    let largestScreen = 0;
+    let largestGutter = 0;
+    let smallestGutter = 999999;
 
     // Create max widths for each screen size which equals to the screen margin
     // setting.
     const keys = Object.keys(screens);
     keys.forEach((key) => {
+      if (largestScreen < parseInt(screens[key])) largestScreen = parseInt(screens[key]);
+
       if (theme(`decanter.screenMargins.${key}`)) {
         const gutterWidth = parseInt(theme(`decanter.screenMargins.${key}`));
+        if (largestGutter < gutterWidth) largestGutter = gutterWidth;
+        if (smallestGutter > gutterWidth) smallestGutter = gutterWidth;
 
         maxWdiths[`@screen ${key}`] = {
           maxWidth: 'calc(100vw - ' + (gutterWidth * 2) + 'px)',
         };
       }
     });
-
+      
+    const key = `@media only screen and (min-width: ${largestScreen + (largestGutter * 2)}px)`
     const components = {
       // Center an element horizontally.
-      '.centered-container, .cc': {
-        maxWidth: 'calc(100vw - ' + (parseInt(theme(`decanter.screenMargins.xs`)) * 2) + 'px)',
+      '.centered': {
+        maxWidth: 'calc(100vw - ' + (smallestGutter * 2) + 'px)',
         width: '100%',
         marginLeft: 'auto',
         marginRight: 'auto',
         ...maxWdiths,
-        '@media only screen and (min-width: 1700px)': {
-          maxWidth: '1500px'
+        [key]: {
+          maxWidth: `${largestScreen}px`,
         },
       },
     };


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Change the way the `.centered-container` works. The current solution only works at the outer most container element, often children of `body` or such. Otherwise you get gutters inside gutters inside gutters. This change allows the user to nest the classes and properly set the element to have appropriate gutters at all breakpoints.

ex: 
```
<div class="cc">
   <div class="cc">
    <div class="cc">
       this element would be 450px inset from the window on each side while on 2xl screens, and 75px on each side on mobile. The proposed change would make sure this text would only have 25px on mobile and 150px on 2xl.
    </div>
  </div>
</div>
```

