### PR TITLE
D8CORE-2622 | @jdwjdwjdw | Add landmark banner role to brand bar

### DIFF
--- a/core/src/templates/components/brand-bar/brand-bar.twig
+++ b/core/src/templates/components/brand-bar/brand-bar.twig
@@ -16,10 +16,10 @@
 #}
 {% if external_link_text is empty -%}
   {%- set external_link_text -%}
-    <span class="su-brand-bar__link--a11y">(link is external)</span>
+    <span class="su-brand-bar__link--a11y"> (link is external)</span>
   {% endset %}
 {%- endif %}
 
-<div class="su-brand-bar {{ modifier_class }}">
+<div class="su-brand-bar {{ modifier_class }} " role="banner">
   <div class="su-brand-bar__container"><a {{ attributes }} class="su-brand-bar__logo" href="https://stanford.edu">Stanford University{{ external_link_text }}</a></div>
 </div>


### PR DESCRIPTION
# NOT READY FOR REVIEW

# Summary
- [D8CORE-2622](https://stanfordits.atlassian.net/browse/D8CORE-2622): A11y: Put logo (Brand bar) into a landmark

# Needed By (Date)
- When convenient

# Urgency
- Normal

# Steps to Test

1. Checkout branch
2. Confirm that the brand bar is contained by a banner landmark, as defined at https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/banner.html
3. Review code 🌲 

# Associated Issues and/or People
- [D8CORE-2622](https://stanfordits.atlassian.net/browse/D8CORE-2622): A11y: Put logo (Brand bar) into a landmark


[D8CORE-2622]: https://stanfordits.atlassian.net/browse/D8CORE-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-2622]: https://stanfordits.atlassian.net/browse/D8CORE-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ