### PR TITLE
D8CORE-4365 | @jdwjdwjdw | Update hero image aspect-ratio

### DIFF
--- a/core/src/scss/components/hero/_hero.scss
+++ b/core/src/scss/components/hero/_hero.scss
@@ -76,6 +76,10 @@ $_su-hero-height: (
   width: 100%;
   overflow: hidden;
 
+  @include grid-media-max('sm') {
+    aspect-ratio: 30/11;
+  }
+
   @include grid-media('md') {
     min-height: map-get($_su-hero-height, 'md');
     position: absolute;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [D8CORE-4365](https://stanfordits.atlassian.net/browse/D8CORE-4365): DEV | Provide a consistent image display, our default image dimension (3:1), on all screen size.
- Made aspect ratio below 768px be 30:11, based on the banner dimensions mentioned at https://sitesuserguide.stanford.edu/build-and-design/media-library/images

# Needed By (Date)
- When convenient

# Urgency
- Normal

# Steps to Test

1. Checkout branch
2. Add a basic page top banner or banner paragraph
3. Confirm that the image has a 30:11 aspect ratio below 768px
4. Review code 🤖 

# Associated Issues and/or People
- [D8CORE-4365](https://stanfordits.atlassian.net/browse/D8CORE-4365): DEV | Provide a consistent image display, our default image dimension (3:1), on all screen size.


[D8CORE-4365]: https://stanfordits.atlassian.net/browse/D8CORE-4365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-4365]: https://stanfordits.atlassian.net/browse/D8CORE-4365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ