### PR TITLE
D8CORE-5738 | @jdwjdwjdw | Update global footer and logo

### DIFF
--- a/core/src/templates/components/global-footer/global-footer.twig
+++ b/core/src/templates/components/global-footer/global-footer.twig
@@ -25,7 +25,7 @@
     <div class="su-global-footer__content">
       <nav aria-label="global footer menu">
         <ul class="su-global-footer__menu su-global-footer__menu--global">
-          <li><a href="https://www.stanford.edu" aria-describedby="su-logo">Stanford Home{{ external_link_text }}</a></li>
+          <li><a href="https://www.stanford.edu">Stanford Home{{ external_link_text }}</a></li>
           <li><a href="https://visit.stanford.edu/basics/">Maps &amp; Directions{{ external_link_text }}</a></li>
           <li><a href="https://www.stanford.edu/search/">Search Stanford{{ external_link_text }}</a></li>
           <li><a href="https://emergency.stanford.edu">Emergency Info{{ external_link_text }}</a></li>

--- a/core/src/templates/components/logo/logo.twig
+++ b/core/src/templates/components/logo/logo.twig
@@ -18,4 +18,4 @@
   {% endset %}
 {%- endif %}
 
-<a {{ attributes }} id="su-logo" class="su-logo {{ modifier_class }}" href="{{ href|default('https://www.stanford.edu') }}">{{ logo_text|default('Stanford<br>University')|raw }}{{ external_link_text }}</a>
+<a {{ attributes }} id="su-logo" class="su-logo {{ modifier_class }}" aria-hidden="true" tabindex="-1" href="{{ href|default('https://www.stanford.edu') }}">{{ logo_text|default('Stanford<br>University')|raw }}{{ external_link_text }}</a>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- [D8CORE-5738](https://stanfordits.atlassian.net/browse/D8CORE-5738) A11y | Decanter Global Footer: Links have different text and go to the same place
- Per [Caryl's comments in the ticket](https://stanfordits.atlassian.net/browse/D8CORE-5738?focusedCommentId=139522), removing the `aria-describedby` from the Stanford Home link, and adding `aria-hidden="true" tabindex="-1"` in the `<a>`.

# Needed By (Date)
- EOD Thursday 6/29

# Urgency
- High

# Steps to Test

1. Checkout branch and import updated decanter into cardinalsites environment
2. Confirm that the changes are being shown correctly
3. Review code

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- [D8CORE-5738](https://stanfordits.atlassian.net/browse/D8CORE-5738) A11y | Decanter Global Footer: Links have different text and go to the same place


[D8CORE-5738]: https://stanfordits.atlassian.net/browse/D8CORE-5738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D8CORE-5738]: https://stanfordits.atlassian.net/browse/D8CORE-5738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ