### PR TITLE
v7 - Remove su- prefix; update sans and serif fonts; add variant group-hocus-within:

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ To see a live demo of Decanter v7 please [view the v7 styleguide](https://decant
 Decanter is a web design and development system for Stanford University.
 It includes a responsive layout system and a browsable collection of design patterns
 that can be used in any Stanford project.
-For Decanter v7, instead of using SASS/SCSS with the BEM naming convention, we use [TailwindCSS](https://tailwindcss.com/) to generate utility classes with some customization needed for our Stanford design system.
+For Decanter v7, instead of using SASS/SCSS with the BEM naming convention, we use [Tailwind CSS](https://tailwindcss.com/) to generate utility classes with some customization needed for our Stanford design system.
 
 ## Assets
-We have removed all assets from the repo in Decanter 7. Instead, we are using remote third party resources for our fonts and icons.
+We have removed all assets from the repo in Decanter v7. Instead, we are using remote third party resources for our fonts and icons.
 
 ### Fonts
 - For Source Sans Pro, Source Serif Pro, Roboto Slab, Roboto Mono - we include them using the `@import` method from [Google Fonts](https://fonts.google.com/).
@@ -24,7 +24,7 @@ We have removed all assets from the repo in Decanter 7. Instead, we are using re
 
 ### Icons
 - We have removed FontAwesome (dependency and asset) completely from Decanter v7. For those who would like to continue using FontAwesome, please feel free to do so and include them using methods that are suitable for your own projects.
-- We recommend using the [react-hero-icon](https://www.npmjs.com/package/react-hero-icon) package as [Hero Icons](https://heroicons.com/) are created by the TailwindCSS team and are open source. They can be included as SVG or JSX elements.
+- We recommend using the [heroicons](https://github.com/tailwindlabs/heroicons) package as [Hero Icons](https://heroicons.com/) are created by the Tailwind CSS team and are open source. They can be included as SVG or JSX elements.
 
 
 ## Accessibility

--- a/fonts.css
+++ b/fonts.css
@@ -1,8 +1,7 @@
 @charset "UTF-8";
 
 /** Source Sans Pro, Source Serif Pro, Roboto Slab, Roboto Mono (regular only) */
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto+Slab:wght@300;400;700&family=Source+Sans+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&family=Source+Serif+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap');
-
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto+Slab:wght@300;400;700&family=Source+Sans+3:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&family=Source+Serif+4:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&display=swap');
 @font-face {
   font-family: "Stanford";
   src: url("https://www-media.stanford.edu/assets/fonts/stanford.woff") format("woff"), url("https://www-media.stanford.edu/assets/fonts/stanford.ttf") format("truetype");

--- a/fonts.css
+++ b/fonts.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-/** Source Sans Pro, Source Serif Pro, Roboto Slab, Roboto Mono (regular only) */
+/** Source Sans 3, Source Serif 4, Roboto Slab, Roboto Mono (regular only) */
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto+Slab:wght@300;400;700&family=Source+Sans+3:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&family=Source+Serif+4:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&display=swap');
 @font-face {
   font-family: "Stanford";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,23 +11,34 @@
       "dependencies": {
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.3",
-        "@tailwindcss/line-clamp": "^0.4.2",
-        "tailwindcss": "^3.3.1"
+        "@tailwindcss/line-clamp": "^0.4.4",
+        "tailwindcss": "^3.3.2"
       },
       "devDependencies": {
         "auto-changelog": "^2.2.1",
-        "autoprefixer": "^10.4.13",
+        "autoprefixer": "^10.4.14",
         "eslint": "^7.14",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-prettier": "^8.3.0",
         "eslint-config-standard": "^16.0.2",
         "eslint-plugin-prettier": "^3.4.0",
         "light-server": "^2.9.1",
-        "postcss": "^8.4.21",
+        "postcss": "^8.4.25",
         "postcss-import": "^13.0.0",
         "postcss-loader": "^4.0.0",
         "postcss-nested": "^5.0.1",
         "prettier": "^2.2.1"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -300,9 +311,9 @@
       }
     },
     "node_modules/@tailwindcss/line-clamp": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz",
-      "integrity": "sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
       "peerDependencies": {
         "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
@@ -766,9 +777,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
       "dev": true,
       "funding": [
         {
@@ -781,8 +792,8 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001464",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -947,9 +958,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001457",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz",
-      "integrity": "sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==",
+      "version": "1.0.30001514",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz",
+      "integrity": "sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==",
       "dev": true,
       "funding": [
         {
@@ -959,6 +970,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -1029,7 +1044,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -3020,9 +3036,9 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
-      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
       "engines": {
         "node": ">=10"
       }
@@ -3261,9 +3277,15 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -3673,9 +3695,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
+      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3684,10 +3706,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -3713,9 +3739,9 @@
       }
     },
     "node_modules/postcss-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
-      "integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
@@ -3727,19 +3753,19 @@
         "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
-        "postcss": "^8.3.3"
+        "postcss": "^8.4.21"
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
-      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
+      "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
       "dependencies": {
         "lilconfig": "^2.0.5",
-        "yaml": "^1.10.2"
+        "yaml": "^2.1.1"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
       },
       "funding": {
         "type": "opencollective",
@@ -3756,6 +3782,14 @@
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/postcss-loader": {
@@ -3919,17 +3953,6 @@
         }
       ]
     },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4041,11 +4064,11 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -4663,44 +4686,40 @@
       "dev": true
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.1.tgz",
-      "integrity": "sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
+      "integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
       "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
-        "color-name": "^1.1.4",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.12",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.17.2",
-        "lilconfig": "^2.0.6",
+        "jiti": "^1.18.2",
+        "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.0.9",
-        "postcss-import": "^14.1.0",
-        "postcss-js": "^4.0.0",
-        "postcss-load-config": "^3.1.4",
-        "postcss-nested": "6.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
         "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
-        "quick-lru": "^5.1.1",
-        "resolve": "^1.22.1",
-        "sucrase": "^3.29.0"
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
         "tailwindcss": "lib/cli.js"
       },
       "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.9"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tailwindcss/node_modules/glob-parent": {
@@ -4715,27 +4734,27 @@
       }
     },
     "node_modules/tailwindcss/node_modules/postcss-import": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-      "integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
         "resolve": "^1.1.7"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
       }
     },
     "node_modules/tailwindcss/node_modules/postcss-nested": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.0.tgz",
-      "integrity": "sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
+      "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.10"
+        "postcss-selector-parser": "^6.0.11"
       },
       "engines": {
         "node": ">=12.0"
@@ -5232,12 +5251,18 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
     }
   },
   "dependencies": {
+    "@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -5456,9 +5481,9 @@
       }
     },
     "@tailwindcss/line-clamp": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz",
-      "integrity": "sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
       "requires": {}
     },
     "@types/eslint": {
@@ -5858,13 +5883,13 @@
       }
     },
     "autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001464",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -5982,9 +6007,9 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001457",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz",
-      "integrity": "sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==",
+      "version": "1.0.30001514",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz",
+      "integrity": "sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==",
       "dev": true
     },
     "chalk": {
@@ -6031,7 +6056,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "commander": {
       "version": "7.2.0",
@@ -7551,9 +7577,9 @@
       }
     },
     "lilconfig": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
-      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -7745,9 +7771,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -8032,11 +8058,11 @@
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ=="
     },
     "postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
+      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
       "requires": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -8053,20 +8079,27 @@
       }
     },
     "postcss-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
-      "integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
       "requires": {
         "camelcase-css": "^2.0.1"
       }
     },
     "postcss-load-config": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
-      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.1.tgz",
+      "integrity": "sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==",
       "requires": {
         "lilconfig": "^2.0.5",
-        "yaml": "^1.10.2"
+        "yaml": "^2.1.1"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+          "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ=="
+        }
       }
     },
     "postcss-loader": {
@@ -8167,11 +8200,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
-    "quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8259,11 +8287,11 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "requires": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -8732,34 +8760,33 @@
       }
     },
     "tailwindcss": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.1.tgz",
-      "integrity": "sha512-Vkiouc41d4CEq0ujXl6oiGFQ7bA3WEhUZdTgXAhtKxSy49OmKs8rEfQmupsfF0IGW8fv2iQkp1EVUuapCFrZ9g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
+      "integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
       "requires": {
+        "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
-        "color-name": "^1.1.4",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.12",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.17.2",
-        "lilconfig": "^2.0.6",
+        "jiti": "^1.18.2",
+        "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.0.9",
-        "postcss-import": "^14.1.0",
-        "postcss-js": "^4.0.0",
-        "postcss-load-config": "^3.1.4",
-        "postcss-nested": "6.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
         "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
-        "quick-lru": "^5.1.1",
-        "resolve": "^1.22.1",
-        "sucrase": "^3.29.0"
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -8771,9 +8798,9 @@
           }
         },
         "postcss-import": {
-          "version": "14.1.0",
-          "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-14.1.0.tgz",
-          "integrity": "sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==",
+          "version": "15.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+          "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
           "requires": {
             "postcss-value-parser": "^4.0.0",
             "read-cache": "^1.0.0",
@@ -8781,11 +8808,11 @@
           }
         },
         "postcss-nested": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.0.tgz",
-          "integrity": "sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
+          "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
           "requires": {
-            "postcss-selector-parser": "^6.0.10"
+            "postcss-selector-parser": "^6.0.11"
           }
         }
       }
@@ -9131,7 +9158,8 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,19 +31,19 @@
   "dependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.3",
-    "@tailwindcss/line-clamp": "^0.4.2",
-    "tailwindcss": "^3.3.1"
+    "@tailwindcss/line-clamp": "^0.4.4",
+    "tailwindcss": "^3.3.2"
   },
   "devDependencies": {
     "auto-changelog": "^2.2.1",
-    "autoprefixer": "^10.4.13",
+    "autoprefixer": "^10.4.14",
     "eslint": "^7.14",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-prettier": "^3.4.0",
     "light-server": "^2.9.1",
-    "postcss": "^8.4.21",
+    "postcss": "^8.4.25",
     "postcss-import": "^13.0.0",
     "postcss-loader": "^4.0.0",
     "postcss-nested": "^5.0.1",

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-/** Source Sans Pro, Source Serif Pro, Roboto Slab, Roboto Mono (regular only) */
+/** Source Sans 3, Source Serif 4, Roboto Slab, Roboto Mono (regular only) */
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto+Slab:wght@300;400;700&family=Source+Sans+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&family=Source+Serif+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap');
 
 @font-face {

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 
 /** Source Sans 3, Source Serif 4, Roboto Slab, Roboto Mono (regular only) */
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto+Slab:wght@300;400;700&family=Source+Sans+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&family=Source+Serif+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono&family=Roboto+Slab:wght@300;400;700&family=Source+Sans+3:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&family=Source+Serif+4:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&display=swap');
 
 @font-face {
   font-family: "Stanford";

--- a/src/plugins/components/link/stretched-link.js
+++ b/src/plugins/components/link/stretched-link.js
@@ -1,7 +1,7 @@
 /**
  * Make any HTML element clickable by stretching a nested link
  * For example, wrap the <a> tag around the headline of a card
- * Add this su-stretched-link class to the <a> tag to make the whole card clickable
+ * Add this stretched-link class to the <a> tag to make the whole card clickable
  * Based on Bootstrap's idea https://getbootstrap.com/docs/4.3/utilities/stretched-link/
  */
 module.exports = function () {

--- a/src/plugins/components/typography/modular-typography.js
+++ b/src/plugins/components/typography/modular-typography.js
@@ -1,8 +1,8 @@
 /**
  * Decanter's responsive modular typography utilities
- * su-type-0 is the base step = 1em; su-type-9 is the largest available currently
+ * type-0 is the base step = 1em; type-9 is the largest available currently
  * Each step up is progressively larger with different font sizes for mobile, tablet and desktop breakpoints
- * For example, try su-type-2 for a medium sized card headline and su-type-7 for a hero banner splash text
+ * For example, try type-2 for a medium sized card headline and type-7 for a hero banner splash text
  */
 module.exports = function () {
   return function ({ addComponents, theme }) {

--- a/src/plugins/theme/decanter.js
+++ b/src/plugins/theme/decanter.js
@@ -18,8 +18,8 @@ module.exports = function () {
   const modtype = {};
 
   // Decanter's reponsive modular typography system
-  // su-type-0 is the base step = 1em
-  // su-type-1 to su-type-9 (largest) available
+  // type-0 is the base step = 1em
+  // type-1 to type-9 (largest) available
   // Each step includes difference font sizes and letterspacing for mobile, tablet and desktop breakpoints
   // Generate responsive modular typography steps from 1 to 9
   for (let i = 1; i < 10; i += 1) {

--- a/src/plugins/theme/fontFamily.js
+++ b/src/plugins/theme/fontFamily.js
@@ -5,6 +5,7 @@ module.exports = function () {
   return {
     mono: ['"Roboto Mono"', 'Menlo', '"Courier New"', 'monospace'],
     sans: [
+      '"Source Sans 3"',
       '"Source Sans Pro"',
       '"Helvetica Neue"',
       'Helvetica',
@@ -12,6 +13,7 @@ module.exports = function () {
       'sans-serif',
     ],
     serif: [
+      '"Source Serif 4"',
       '"Source Serif Pro"',
       'Georgia',
       'Times',

--- a/src/plugins/theme/fontSize.js
+++ b/src/plugins/theme/fontSize.js
@@ -1,10 +1,10 @@
 /**
  * Font Size Defaults.
- * Also see our custom modular typography classes (.su-type-0 to .su-type-6).
+ * Also see our custom modular typography classes (.type-0 to .type-6).
  */
 module.exports = function () {
   return {
-    // su-text-11 to su-text-30 correspond to font sizes from 12px to 30px (in rem units)
+    // text-11 to text-30 correspond to font sizes from 12px to 30px (in rem units)
     11: '1.1rem',
     12: '1.2rem',
     13: '1.3rem',
@@ -28,12 +28,12 @@ module.exports = function () {
     /**
      * Font sizes classes for use in modular typography utilities.
      * To take full advantage of modular typography which inlude letter spacing adjustments propotional to font sizes,
-     * use su-type-0 to su-type-9 instead
+     * use type-0 to type-9 instead
      * See src/plugins/theme/decanter.js
      */
-    m0: '1em', // su-text-m0 equals to 1em (modular step 0 = base)
-    m1: '1.25em', // su-text-m1 = 1.25 x 1em (modular step 1)
-    m2: '1.56em', // su-text-m2 = 1.25 x 1.25 x 1em (modular step 2) and so on
+    m0: '1em', // text-m0 equals to 1em (modular step 0 = base)
+    m1: '1.25em', // text-m1 = 1.25 x 1em (modular step 1)
+    m2: '1.56em', // text-m2 = 1.25 x 1.25 x 1em (modular step 2) and so on
     m3: '1.95em',
     m4: '2.44em',
     m5: '3.05em',
@@ -41,7 +41,7 @@ module.exports = function () {
     m7: '4.77em',
     m8: '5.96em',
     m9: '7.45em',
-    // su-text--m1 doesn't use the 1.25 scale factor.
+    // text--m1 doesn't use the 1.25 scale factor.
     // Merely a convenience class for a slightly smaller font size than the base step
     '-m1': '0.9em',
   };

--- a/src/plugins/theme/fontWeight.js
+++ b/src/plugins/theme/fontWeight.js
@@ -4,6 +4,7 @@
 
 module.exports = function () {
   return {
-    regular: '400', // su-font-normal = 400 font weight for Tailwind, but Decanter users are used to su-font-regular for the same thing
+    // TW class for normal font weight is font-normal, but Decanter v6 users are used to font-regular for the same thing
+    regular: '400',
   };
 };

--- a/static/index.html
+++ b/static/index.html
@@ -207,7 +207,7 @@
               </div>
               <h2>Comparison of Different Base Font Size Options</h2>
               <div class="basefont-19 rs-mb-4">
-                <h3>H3 .basefont-19</h3>
+                <h3 class="font-serif">H3 .basefont-19</h3>
                 <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>
@@ -229,7 +229,7 @@
               </div>
 
               <div class="basefont-20 rs-mb-4">
-                <h3>H3 .basefont-20</h3>
+                <h3 class="font-serif">H3 .basefont-20</h3>
                 <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>
@@ -251,7 +251,7 @@
               </div>
 
               <div class="rs-mb-4">
-                <h3>H3 Default body font size (21px)</h3>
+                <h3 class="font-serif">H3 Default body font size (21px)</h3>
                 <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>
@@ -273,7 +273,7 @@
               </div>
 
               <div class="basefont-22 rs-mb-4">
-                <h3>H3 .basefont-22</h3>
+                <h3 class="font-serif">H3 .basefont-22</h3>
                 <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>
@@ -295,7 +295,7 @@
               </div>
 
               <div class="basefont-23 rs-mb-4">
-                <h3>H3 .basefont-23</h3>
+                <h3 class="font-serif">H3 .basefont-23</h3>
                 <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>

--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr" class="su-smooth-scroll">
+<html lang="en" dir="ltr" class="smooth-scroll">
 
 <head>
   <meta charset="utf-8">
@@ -8,171 +8,171 @@
   <link rel="stylesheet" href="./css/decanter.css">
 </head>
 
-<body class="su-debug-screens">
+<body class="debug-screens">
 
   <!-- MAIN DEVELOPMENT AREA -->
-  <a href="#top" class="su-skiplink">Skip to main content</a>
-  <div class="su-bg-digital-red su-pt-5 su-pb-1">
-    <div class="su-cc">
-      <a class="su-logo su-text-white hocus:su-text-white su-text-20" href="https://stanford.edu">Stanford
+  <a href="#top" class="skiplink">Skip to main content</a>
+  <div class="bg-digital-red pt-5 pb-1">
+    <div class="cc">
+      <a class="logo text-white hocus:text-white text-20" href="https://stanford.edu">Stanford
         University</a>
     </div>
   </div>
-  <div role="banner" class="su-rs-py-6 su-bg-gradient-to-b su-from-black su-to-plum su-text-white">
-    <div class="su-centered-container">
-      <h1 class="su-splash-text">Decanter 7 With Tailwind Test Page.</h1>
-      <p class="su-intro-text">This is a test page filled with common HTML elements to be used to provide visual
+  <div role="banner" class="rs-py-6 bg-gradient-to-b from-black to-plum text-white">
+    <div class="centered-container">
+      <h1 class="splash-text">Decanter 7 With Tailwind Test Page.</h1>
+      <p class="intro-text">This is a test page filled with common HTML elements to be used to provide visual
         feedback whilst building CSS systems and frameworks.</p>
     </div>
   </div>
   <main id="top">
     <!-- Nav pills -->
-    <header class="su-bg-black-20 su-text-white su-rs-py-4">
-      <div class="su-cc">
+    <header class="bg-black-20 text-white rs-py-4">
+      <div class="cc">
         <nav aria-label="table of content">
-          <h2 class="su-type-5"><a href="#text"
-              class="su-text-black hover:su-underline focus:su-underline">Typography</a></h2>
-          <ul class="su-list-unstyled su-text-16 md:su-text-20 su-rs-mb-4">
-            <li class="su-inline-block su-mb-12"><a href="#logo"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Stanford
+          <h2 class="type-5"><a href="#text"
+              class="text-black hover:underline focus:underline">Typography</a></h2>
+          <ul class="list-unstyled text-16 md:text-20 rs-mb-4">
+            <li class="inline-block mb-12"><a href="#logo"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Stanford
                 Logos</a></li>
-            <li class="su-inline-block su-mb-12"><a href="#text__headings"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Headings</a>
+            <li class="inline-block mb-12"><a href="#text__headings"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Headings</a>
             </li>
-            <li class="su-inline-block su-mb-12"><a href="#text__paragraphs"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Paragraphs</a>
+            <li class="inline-block mb-12"><a href="#text__paragraphs"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Paragraphs</a>
             </li>
-            <li class="su-inline-block su-mb-12"><a href="#text__blockquotes"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Blockquotes</a>
+            <li class="inline-block mb-12"><a href="#text__blockquotes"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Blockquotes</a>
             </li>
-            <li class="su-inline-block su-mb-12"><a href="#text__lists"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Lists</a>
+            <li class="inline-block mb-12"><a href="#text__lists"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Lists</a>
             </li>
-            <li class="su-inline-block su-mb-12"><a href="#text__code"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Code</a>
+            <li class="inline-block mb-12"><a href="#text__code"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Code</a>
             </li>
-            <li class="su-inline-block su-mb-12"><a href="#text__wysiwyg"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">WYSIWYG
+            <li class="inline-block mb-12"><a href="#text__wysiwyg"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">WYSIWYG
                 Text</a></li>
-            <li class="su-inline-block su-mb-12"><a href="#text__inline"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Inline
+            <li class="inline-block mb-12"><a href="#text__inline"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Inline
                 elements</a></li>
           </ul>
 
-          <h2 class="su-type-5"><a href="#color-palette"
-              class="su-text-black hover:su-underline focus:su-underline">Colors</a></h2>
-          <ul class="su-list-unstyled su-text-16 md:su-text-20 su-rs-mb-4">
-            <li class="su-inline-block su-mb-12"><a href="#color-palette"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Colors</a>
+          <h2 class="type-5"><a href="#color-palette"
+              class="text-black hover:underline focus:underline">Colors</a></h2>
+          <ul class="list-unstyled text-16 md:text-20 rs-mb-4">
+            <li class="inline-block mb-12"><a href="#color-palette"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Colors</a>
             </li>
           </ul>
 
-          <h2 class="su-type-5"><a href="#html-elements"
-              class="su-text-black hover:su-underline focus:su-underline">HTML Elements</a></h2>
-          <ul class="su-list-unstyled su-text-16 md:su-text-20 su-rs-mb-4">
-            <li class="su-inline-block su-mb-12"><a href="#drop-shadows"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Drop
+          <h2 class="type-5"><a href="#html-elements"
+              class="text-black hover:underline focus:underline">HTML Elements</a></h2>
+          <ul class="list-unstyled text-16 md:text-20 rs-mb-4">
+            <li class="inline-block mb-12"><a href="#drop-shadows"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Drop
                 Shadows</a></li>
-            <li class="su-inline-block su-mb-12"><a href="#text__tables"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Tables</a>
+            <li class="inline-block mb-12"><a href="#text__tables"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Tables</a>
             </li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#embedded__images">Images</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#embedded__youtube">Embed Streaming Video</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#embedded__audio">Audio</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#embedded__video">Video</a></li>
-            <li class="su-inline-block su-mb-12"><a href="#text__hr"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Horizontal
+            <li class="inline-block mb-12"><a href="#text__hr"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Horizontal
                 rules</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#embedded__meter">Meter</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#embedded__progress">Progress</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#embedded__svg">Inline SVG</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#embedded__iframe">Iframes</a></li>
           </ul>
-          <h2 class="su-type-5"><a href="#forms" class="su-text-black hover:su-underline focus:su-underline">Form
+          <h2 class="type-5"><a href="#forms" class="text-black hover:underline focus:underline">Form
               elements</a></h2>
-          <ul class="su-list-unstyled su-text-16 md:su-text-20 su-rs-mb-4">
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+          <ul class="list-unstyled text-16 md:text-20 rs-mb-4">
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#forms__input">Input fields</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#forms__select">Select menus</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#forms__checkbox">Checkboxes</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#forms__radio">Radio buttons</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#forms__textareas">Textareas</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#forms__html5">HTML5 inputs</a></li>
-            <li class="su-inline-block su-mb-12 su-mr-12"><a
-                class="su-inline-block su-py-8 su-px-20 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors"
+            <li class="inline-block mb-12 mr-12"><a
+                class="inline-block py-8 px-20 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors"
                 href="#forms__action">Action buttons</a></li>
           </ul>
-          <h2 class="su-type-5"><a href="#layouts" class="su-text-black hover:su-underline focus:su-underline">Layouts &
+          <h2 class="type-5"><a href="#layouts" class="text-black hover:underline focus:underline">Layouts &
               Grids</a></h2>
-          <ul class="su-list-unstyled su-text-16 md:su-text-20 su-rs-mb-4">
-            <li class="su-inline-block su-mb-12"><a href="#css-grid"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">CSS
+          <ul class="list-unstyled text-16 md:text-20 rs-mb-4">
+            <li class="inline-block mb-12"><a href="#css-grid"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">CSS
                 Grid</a></li>
-            <li class="su-inline-block su-mb-12"><a href="#flex-grid"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Flex
+            <li class="inline-block mb-12"><a href="#flex-grid"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Flex
                 Grid</a></li>
-            <li class="su-inline-block su-mb-12"><a href="#aspect-ratio"
-                class="su-inline-block su-py-8 su-px-20 su-mr-12 su-bg-spirited-dark hocus:su-bg-archway-dark su-rounded-full su-text-white hocus:su-text-white su-no-underline su-transition-colors">Aspect
+            <li class="inline-block mb-12"><a href="#aspect-ratio"
+                class="inline-block py-8 px-20 mr-12 bg-spirited-dark hocus:bg-archway-dark rounded-full text-white hocus:text-white no-underline transition-colors">Aspect
                 Ratio Containers</a></li>
           </ul>
         </nav>
       </div>
     </header>
     <!-- Typography section -->
-    <section class="su-rs-mb-3">
-      <header id="text" class="su-rs-py-4 su-bg-black-90">
-        <div class="su-cc">
-          <h2 class="su-type-6 su-text-white su-mb-0 su-text-center">Typography</h2>
+    <section class="rs-mb-3">
+      <header id="text" class="rs-py-4 bg-black-90">
+        <div class="cc">
+          <h2 class="type-6 text-white mb-0 text-center">Typography</h2>
         </div>
       </header>
-      <div class="su-cc su-flex su-flex-col md:su-flex-row su-rs-py-6 su-overflow-x-hidden">
-        <div class="su-mx-auto su-w-full lg:su-w-8/12">
-          <article id="logo" class="su-rs-mb-5">
-            <h3 class="su-type-5 su-text-lagunita-light">Stanford Logos</h3>
-            <div class="su-grid su-grid-cols-1 md:su-grid-cols-2 su-grid-gap">
+      <div class="cc flex flex-col md:flex-row rs-py-6 overflow-x-hidden">
+        <div class="mx-auto w-full lg:w-8/12">
+          <article id="logo" class="rs-mb-5">
+            <h3 class="type-5 text-lagunita-light">Stanford Logos</h3>
+            <div class="grid grid-cols-1 md:grid-cols-2 grid-gap">
               <div>
-                <h4 class="su-type-3">Horizontal Version</h4>
-                <a class="su-logo su-text-cardinal-red hocus:su-text-cardinal-red su-type-3"
+                <h4 class="type-3">Horizontal Version</h4>
+                <a class="logo text-cardinal-red hocus:text-cardinal-red type-3"
                   href="https://stanford.edu">Stanford University</a>
               </div>
               <div>
-                <h4 class="su-type-3">Stacked Version</h4>
-                <a class="su-logo su-text-cardinal-red hocus:su-text-cardinal-red su-type-3"
+                <h4 class="type-3">Stacked Version</h4>
+                <a class="logo text-cardinal-red hocus:text-cardinal-red type-3"
                   href="https://stanford.edu">Stanford<br>University</a>
               </div>
             </div>
           </article>
-          <article id="text__headings" class="su-rs-mb-5">
-            <h3 class="su-type-5 su-text-lagunita-light">Headings & Display Type</h3>
+          <article id="text__headings" class="rs-mb-5">
+            <h3 class="type-5 text-lagunita-light">Headings & Display Type</h3>
             <div>
-              <span class="su-splash-text su-rs-mb-0">Splash Text</span>
+              <span class="splash-text rs-mb-0">Splash Text</span>
               <h1>Heading 1</h1>
               <h2>Heading 2</h2>
               <h3>Heading 3</h3>
@@ -181,12 +181,12 @@
               <h6>Heading 6</h6>
             </div>
           </article>
-          <article id="text__paragraphs" class="su-rs-mb-5">
+          <article id="text__paragraphs" class="rs-mb-5">
             <div>
-              <h3 class="su-type-5 su-text-lagunita-light">Paragraphs</h3>
-              <div class="su-rs-mb-4">
-                <h4 class="su-type-4">Intro and Paragraph (Base Font Size 21px)</h4>
-                <p class="su-intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
+              <h3 class="type-5 text-lagunita-light">Paragraphs</h3>
+              <div class="rs-mb-4">
+                <h4 class="type-4">Intro and Paragraph (Base Font Size 21px)</h4>
+                <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>
                 <p><strong>Regular paragraph</strong> (from the Greek paragraphos, “to write beside” or “written
@@ -194,21 +194,21 @@
                   point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any
                   language, paragraphs are usually an expected part of formal writing, used to organize longer prose.
                 </p>
-                <p class="su-big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
-                <p class="su-card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
               </div>
               <h2>Comparison of Different Base Font Size Options</h2>
-              <div class="su-basefont-19 su-rs-mb-4">
-                <h3>H3 .su-basefont-19</h3>
-                <p class="su-intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
+              <div class="basefont-19 rs-mb-4">
+                <h3>H3 .basefont-19</h3>
+                <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>
                 <p><strong>Regular paragraph</strong> (from the Greek paragraphos, “to write beside” or “written
@@ -216,21 +216,21 @@
                   point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any
                   language, paragraphs are usually an expected part of formal writing, used to organize longer prose.
                 </p>
-                <p class="su-big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
-                <p class="su-card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
               </div>
 
-              <div class="su-basefont-20 su-rs-mb-4">
-                <h3>H3 .su-basefont-20</h3>
-                <p class="su-intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
+              <div class="basefont-20 rs-mb-4">
+                <h3>H3 .basefont-20</h3>
+                <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>
                 <p><strong>Regular paragraph</strong> (from the Greek paragraphos, “to write beside” or “written
@@ -238,21 +238,21 @@
                   point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any
                   language, paragraphs are usually an expected part of formal writing, used to organize longer prose.
                 </p>
-                <p class="su-big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
-                <p class="su-card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
               </div>
 
-              <div class="su-rs-mb-4">
+              <div class="rs-mb-4">
                 <h3>H3 Default body font size (21px)</h3>
-                <p class="su-intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
+                <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>
                 <p><strong>Regular paragraph</strong> (from the Greek paragraphos, “to write beside” or “written
@@ -260,21 +260,21 @@
                   point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any
                   language, paragraphs are usually an expected part of formal writing, used to organize longer prose.
                 </p>
-                <p class="su-big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
-                <p class="su-card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
               </div>
 
-              <div class="su-basefont-22 su-rs-mb-4">
-                <h3>H3 .su-basefont-22</h3>
-                <p class="su-intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
+              <div class="basefont-22 rs-mb-4">
+                <h3>H3 .basefont-22</h3>
+                <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>
                 <p><strong>Regular paragraph</strong> (from the Greek paragraphos, “to write beside” or “written
@@ -282,21 +282,21 @@
                   point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any
                   language, paragraphs are usually an expected part of formal writing, used to organize longer prose.
                 </p>
-                <p class="su-big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
-                <p class="su-card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
               </div>
 
-              <div class="su-basefont-23 su-rs-mb-4">
-                <h3>H3 .su-basefont-23</h3>
-                <p class="su-intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
+              <div class="basefont-23 rs-mb-4">
+                <h3>H3 .basefont-23</h3>
+                <p class="intro-text">Intro text max-width is 65ch. A paragraph (from the Greek paragraphos, “to
                   write beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea.</p>
                 <p><strong>Regular paragraph</strong> (from the Greek paragraphos, “to write beside” or “written
@@ -304,12 +304,12 @@
                   point or idea. A paragraph consists of one or more sentences. Though not required by the syntax of any
                   language, paragraphs are usually an expected part of formal writing, used to organize longer prose.
                 </p>
-                <p class="su-big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="big-paragraph"><strong>Big paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
                   used to organize longer prose.</p>
-                <p class="su-card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
+                <p class="card-paragraph"><strong>Card paragraph</strong> (from the Greek paragraphos, “to write
                   beside” or “written beside”) is a <a href="#">self-contained unit of a discourse</a> in writing
                   dealing with a particular point or idea. A paragraph consists of one or more sentences. Though not
                   required by the syntax of any language, paragraphs are usually an expected part of formal writing,
@@ -317,9 +317,9 @@
               </div>
             </div>
           </article>
-          <article id="text__blockquotes" class="su-rs-mb-5">
+          <article id="text__blockquotes" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Blockquotes</h3>
+              <h3 class="type-5 text-lagunita-light">Blockquotes</h3>
             </header>
             <div>
               <blockquote>
@@ -331,39 +331,39 @@
               </blockquote>
             </div>
           </article>
-          <article id="text__lists" class="su-rs-mb-5">
+          <article id="text__lists" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Lists</h3>
+              <h3 class="type-5 text-lagunita-light">Lists</h3>
             </header>
-            <h4 class="su-type-4">Definition List</h4>
-            <dl class="su-rs-mb-3">
+            <h4 class="type-4">Definition List</h4>
+            <dl class="rs-mb-3">
               <dt>Definition List Title 1</dt>
               <dd>This is a definition list division.</dd>
               <dt>Definition List Title 2</dt>
               <dd>This is a definition list division.</dd>
             </dl>
-            <h4 class="su-type-4">Ordered List</h4>
-            <ol class="su-rs-mb-3">
+            <h4 class="type-4">Ordered List</h4>
+            <ol class="rs-mb-3">
               <li>List Item 1</li>
               <li>List Item 2</li>
               <li>List Item 3</li>
             </ol>
-            <h4 class="su-type-4">Unordered List</h4>
-            <ul class="su-rs-mb-3">
+            <h4 class="type-4">Unordered List</h4>
+            <ul class="rs-mb-3">
               <li>List Item 1</li>
               <li>List Item 2</li>
               <li>List Item 3</li>
             </ul>
           </article>
-          <article id="text__code" class="su-rs-mb-5">
+          <article id="text__code" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Code & Preformatted Text</h3>
+              <h3 class="type-5 text-lagunita-light">Code & Preformatted Text</h3>
             </header>
             <div>
               <p><strong>Keyboard input:</strong> <kbd>Cmd</kbd></p>
               <p><strong>Inline code:</strong> <code>&lt;div&gt;code&lt;/div&gt;</code></p>
               <p><strong>Sample output:</strong> <samp>This is sample output from a computer program.</samp></p>
-              <h4 class="su-type-4">Pre-formatted Text</h4>
+              <h4 class="type-4">Pre-formatted Text</h4>
               <pre>
 P R E F O R M A T T E D T E X T
 ! " # $ % &amp; ' ( ) * + , - . /
@@ -375,11 +375,11 @@ p q r s t u v w x y z { | } ~
 </pre>
             </div>
           </article>
-          <article id="text__wysiwyg" class="su-rs-mb-5">
+          <article id="text__wysiwyg" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">WYSIWYG Content</h3>
+              <h3 class="type-5 text-lagunita-light">WYSIWYG Content</h3>
             </header>
-            <div class="su-wysiwyg">
+            <div class="wysiwyg">
               <h2>Heading Level 2</h2>
               <p>A block quotation (also known as a long quotation or extract) is a quotation in a written document,
                 that is set off from the main text as a paragraph, or block of text.</p>
@@ -412,9 +412,9 @@ p q r s t u v w x y z { | } ~
                 that is set off from the main text as a paragraph, or block of text.</p>
             </div>
           </article>
-          <article id="text__inline" class="su-rs-mb-5">
+          <article id="text__inline" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Inline Styles</h3>
+              <h3 class="type-5 text-lagunita-light">Inline Styles</h3>
             </header>
             <div>
               <p><a href="#!">This is a text link</a>.</p>
@@ -444,354 +444,354 @@ p q r s t u v w x y z { | } ~
       </div>
     </section>
 
-    <section class="su-rs-mb-3">
-      <header id="color-palette" class="su-rs-py-4 su-bg-black-90">
-        <div class="su-cc">
-          <h2 class="su-type-6 su-text-white su-mb-0 su-text-center">Colors</h2>
+    <section class="rs-mb-3">
+      <header id="color-palette" class="rs-py-4 bg-black-90">
+        <div class="cc">
+          <h2 class="type-6 text-white mb-0 text-center">Colors</h2>
         </div>
       </header>
-      <div class="su-cc su-flex su-flex-col md:su-flex-row su-rs-py-6 su-overflow-x-hidden">
-        <div class="su-mx-auto su-w-full lg:su-w-8/12">
-          <article id="color-palette-black" class="su-rs-mb-5">
+      <div class="cc flex flex-col md:flex-row rs-py-6 overflow-x-hidden">
+        <div class="mx-auto w-full lg:w-8/12">
+          <article id="color-palette-black" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Black</h3>
+              <h3 class="type-5 text-lagunita-light">Black</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-black-true">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-black-true">
                 black-true</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-black">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-black">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-black-90">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-black-90">
                 black-90</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-black-80">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-black-80">
                 black-80</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-black-70">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-black-70">
                 black-70</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-black-60">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-black-60">
                 black-60</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-black-50">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-black-50">
                 black-50</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-black-40">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-black-40">
                 black-40</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-black-30">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-black-30">
                 black-30</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-black-20">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-black-20">
                 black-20</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-black-10">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-black-10">
                 black-10</div>
             </div>
           </article>
 
-          <article id="color-palette-white" class="su-rs-mb-5">
+          <article id="color-palette-white" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">White</h3>
+              <h3 class="type-5 text-lagunita-light">White</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-white">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-white">
                 white</div>
             </div>
           </article>
 
-          <article id="color-palette-digital-red" class="su-rs-mb-5">
+          <article id="color-palette-digital-red" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Digital Red</h3>
+              <h3 class="type-5 text-lagunita-light">Digital Red</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-digital-red">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-digital-red">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-digital-red-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-digital-red-dark">
                 digital-red-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-digital-red-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-digital-red-light">
                 digital-red-light</div>
             </div>
           </article>
 
-          <article id="color-palette-digital-blue" class="su-rs-mb-5">
+          <article id="color-palette-digital-blue" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Digital Blue</h3>
+              <h3 class="type-5 text-lagunita-light">Digital Blue</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-digital-blue">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-digital-blue">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-digital-blue-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-digital-blue-dark">
                 digital-blue-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-digital-blue-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-digital-blue-light">
                 digital-blue-light</div>
             </div>
           </article>
 
-          <article id="color-palette-digital-green" class="su-rs-mb-5">
+          <article id="color-palette-digital-green" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Digital Green</h3>
+              <h3 class="type-5 text-lagunita-light">Digital Green</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-digital-green">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-digital-green">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-digital-green-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-digital-green-dark">
                 digital-green-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-digital-green-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-digital-green-light">
                 digital-green-light</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-digital-green-bright">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-digital-green-bright">
                 digital-green-bright</div>
             </div>
           </article>
 
-          <article id="color-palette-palo-alto" class="su-rs-mb-5">
+          <article id="color-palette-palo-alto" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Palo Alto</h3>
+              <h3 class="type-5 text-lagunita-light">Palo Alto</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-palo-alto">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-palo-alto">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-palo-alto-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-palo-alto-dark">
                 palo-alto-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-palo-alto-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-palo-alto-light">
                 palo-alto-light</div>
             </div>
           </article>
 
-          <article id="color-palette-palo-verde" class="su-rs-mb-5">
+          <article id="color-palette-palo-verde" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Palo Verde</h3>
+              <h3 class="type-5 text-lagunita-light">Palo Verde</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-palo-verde">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-palo-verde">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-palo-verde-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-palo-verde-dark">
                 palo-verde-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-palo-verde-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-palo-verde-light">
                 palo-verde-light</div>
             </div>
           </article>
 
-          <article id="color-palette-olive" class="su-rs-mb-5">
+          <article id="color-palette-olive" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Olive</h3>
+              <h3 class="type-5 text-lagunita-light">Olive</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-olive">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-olive">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-olive-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-olive-dark">
                 olive-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-olive-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-olive-light">
                 olive-light</div>
             </div>
           </article>
 
-          <article id="color-palette-bay" class="su-rs-mb-5">
+          <article id="color-palette-bay" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Bay</h3>
+              <h3 class="type-5 text-lagunita-light">Bay</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-bay">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-bay">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-bay-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-bay-dark">
                 bay-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-bay-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-bay-light">
                 bay-light</div>
             </div>
           </article>
 
-          <article id="color-palette-sky" class="su-rs-mb-5">
+          <article id="color-palette-sky" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Sky</h3>
+              <h3 class="type-5 text-lagunita-light">Sky</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-sky">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-sky">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-sky-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-sky-dark">
                 sky-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-sky-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-sky-light">
                 sky-light</div>
             </div>
           </article>
 
-          <article id="color-palette-lagunita" class="su-rs-mb-5">
+          <article id="color-palette-lagunita" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Lagunita</h3>
+              <h3 class="type-5 text-lagunita-light">Lagunita</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-lagunita">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-lagunita">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-lagunita-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-lagunita-dark">
                 lagunita-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-lagunita-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-lagunita-light">
                 lagunita-light</div>
             </div>
           </article>
 
-          <article id="color-palette-poppy" class="su-rs-mb-5">
+          <article id="color-palette-poppy" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Poppy</h3>
+              <h3 class="type-5 text-lagunita-light">Poppy</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-poppy">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-poppy">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-poppy-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-poppy-dark">
                 poppy-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-poppy-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-poppy-light">
                 poppy-light</div>
             </div>
           </article>
 
-          <article id="color-palette-spirited" class="su-rs-mb-5">
+          <article id="color-palette-spirited" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Spirited</h3>
+              <h3 class="type-5 text-lagunita-light">Spirited</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-spirited">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-spirited">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-spirited-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-spirited-dark">
                 spirited-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-spirited-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-spirited-light">
                 spirited-light</div>
             </div>
           </article>
 
-          <article id="color-palette-illuminating" class="su-rs-mb-5">
+          <article id="color-palette-illuminating" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Illuminating</h3>
+              <h3 class="type-5 text-lagunita-light">Illuminating</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-illuminating">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-illuminating">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-illuminating-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-illuminating-dark">
                 illuminating-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-illuminating-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-illuminating-light">
                 illuminating-light</div>
             </div>
           </article>
 
-          <article id="color-palette-plum" class="su-rs-mb-5">
+          <article id="color-palette-plum" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Plum</h3>
+              <h3 class="type-5 text-lagunita-light">Plum</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-plum">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-plum">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-plum-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-plum-dark">
                 plum-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-plum-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-plum-light">
                 plum-light</div>
             </div>
           </article>
 
-          <article id="color-palette-brick" class="su-rs-mb-5">
+          <article id="color-palette-brick" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Brick</h3>
+              <h3 class="type-5 text-lagunita-light">Brick</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-brick">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-brick">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-brick-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-brick-dark">
                 brick-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-brick-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-brick-light">
                 brick-light</div>
             </div>
           </article>
 
-          <article id="color-palette-archway" class="su-rs-mb-5">
+          <article id="color-palette-archway" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Archway</h3>
+              <h3 class="type-5 text-lagunita-light">Archway</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-archway">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-archway">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-archway-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-archway-dark">
                 archway-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-archway-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-archway-light">
                 archway-light</div>
             </div>
           </article>
 
-          <article id="color-palette-stone" class="su-rs-mb-5">
+          <article id="color-palette-stone" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Stone</h3>
+              <h3 class="type-5 text-lagunita-light">Stone</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-stone">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-stone">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-white su-bg-stone-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-white bg-stone-dark">
                 stone-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-stone-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-stone-light">
                 stone-light</div>
             </div>
           </article>
 
-          <article id="color-palette-foggy" class="su-rs-mb-5">
+          <article id="color-palette-foggy" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Foggy</h3>
+              <h3 class="type-5 text-lagunita-light">Foggy</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-foggy">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-foggy">
                 Default</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-foggy-dark">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-foggy-dark">
                 foggy-dark</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-font-semibold su-border su-border-solid su-border-black-10 su-text-black su-bg-foggy-light">
+                class="rs-py-4 rs-px-1 flex justify-center content-center font-semibold border border-black-10 text-black bg-foggy-light">
                 foggy-light</div>
             </div>
           </article>
@@ -802,51 +802,51 @@ p q r s t u v w x y z { | } ~
 
 
     <!-- HTML Elements section -->
-    <section class="su-rs-mb-3">
-      <header id="html-elements" class="su-rs-py-4 su-bg-black-90">
-        <div class="su-cc">
-          <h2 class="su-type-6 su-text-white su-mb-0 su-text-center">HTML Elements</h2>
+    <section class="rs-mb-3">
+      <header id="html-elements" class="rs-py-4 bg-black-90">
+        <div class="cc">
+          <h2 class="type-6 text-white mb-0 text-center">HTML Elements</h2>
         </div>
       </header>
-      <div class="su-cc su-flex su-flex-col md:su-flex-row su-rs-py-6 su-overflow-x-hidden">
-        <div class="su-mx-auto su-w-full lg:su-w-8/12">
-          <article id="drop-shadows" class="su-rs-mb-5">
+      <div class="cc flex flex-col md:flex-row rs-py-6 overflow-x-hidden">
+        <div class="mx-auto w-full lg:w-8/12">
+          <article id="drop-shadows" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Drop Shadows</h3>
+              <h3 class="type-5 text-lagunita-light">Drop Shadows</h3>
             </header>
-            <div class="su-grid md:su-grid-cols-2 lg:su-grid-cols-3 su-gap-xl md:su-gap-lg 2xl:su-gap-2xl">
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-xl md:gap-lg 2xl:gap-2xl">
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-text-plum su-font-semibold su-bg-white su-border su-border-solid su-border-black-10 su-shadow-none">
-                .su-shadow-none</div>
+                class="rs-py-4 rs-px-1 flex justify-center content-center text-plum font-semibold bg-white border border-black-10 shadow-none">
+                .shadow-none</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-text-plum su-font-semibold su-bg-white su-border su-border-solid su-border-black-10 su-shadow-sm">
-                .su-shadow-sm</div>
+                class="rs-py-4 rs-px-1 flex justify-center content-center text-plum font-semibold bg-white border border-black-10 shadow-sm">
+                .shadow-sm</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-text-plum su-font-semibold su-bg-white su-border su-border-solid su-border-black-10 su-shadow">
-                .su-shadow</div>
+                class="rs-py-4 rs-px-1 flex justify-center content-center text-plum font-semibold bg-white border border-black-10 shadow">
+                .shadow</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-text-plum su-font-semibold su-bg-white su-border su-border-solid su-border-black-10 su-shadow-md">
-                .su-shadow-md</div>
+                class="rs-py-4 rs-px-1 flex justify-center content-center text-plum font-semibold bg-white border border-black-10 shadow-md">
+                .shadow-md</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-text-plum su-font-semibold su-bg-white su-border su-border-solid su-border-black-10 su-shadow-lg">
-                .su-shadow-lg</div>
+                class="rs-py-4 rs-px-1 flex justify-center content-center text-plum font-semibold bg-white border border-black-10 shadow-lg">
+                .shadow-lg</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-text-plum su-font-semibold su-bg-white su-border su-border-solid su-border-black-10 su-shadow-xl">
-                .su-shadow-xl</div>
+                class="rs-py-4 rs-px-1 flex justify-center content-center text-plum font-semibold bg-white border border-black-10 shadow-xl">
+                .shadow-xl</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-text-plum su-font-semibold su-bg-white su-border su-border-solid su-border-black-10 su-shadow-2xl">
-                .su-shadow-2xl</div>
+                class="rs-py-4 rs-px-1 flex justify-center content-center text-plum font-semibold bg-white border border-black-10 shadow-2xl">
+                .shadow-2xl</div>
               <div
-                class="su-rs-py-4 su-rs-px-1 su-flex su-justify-center su-content-center su-text-plum su-font-semibold su-bg-white su-border su-border-solid su-border-black-10 su-shadow-inner">
-                .su-shadow-inner</div>
+                class="rs-py-4 rs-px-1 flex justify-center content-center text-plum font-semibold bg-white border border-black-10 shadow-inner">
+                .shadow-inner</div>
             </div>
           </article>
-          <article id="text__tables" class="su-rs-mb-5">
+          <article id="text__tables" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Tables</h3>
+              <h3 class="type-5 text-lagunita-light">Tables</h3>
             </header>
-            <h4 class="su-type-3">Default Table</h4>
-            <table class="su-rs-mb-4">
+            <h4 class="type-3">Default Table</h4>
+            <table class="rs-mb-4">
               <caption>Table Caption</caption>
               <thead>
                 <tr>
@@ -898,8 +898,8 @@ p q r s t u v w x y z { | } ~
               </tfoot>
             </table>
 
-            <h4 class="su-type-3">Borderless Table</h4>
-            <table class="su-table-borderless">
+            <h4 class="type-3">Borderless Table</h4>
+            <table class="table-borderless">
               <caption>Table Caption</caption>
               <thead>
                 <tr>
@@ -951,21 +951,21 @@ p q r s t u v w x y z { | } ~
               </tfoot>
             </table>
           </article>
-          <article id="embedded__images" class="su-rs-mb-5">
+          <article id="embedded__images" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Images</h3>
+              <h3 class="type-5 text-lagunita-light">Images</h3>
             </header>
             <div>
-              <h4 class="su-type-4">Plain <code>&lt;img&gt;</code> element</h4>
-              <p class="su-rs-mb-3"><img src="http://placekitten.com/600/400" alt="Image alt text"></p>
-              <h4 class="su-type-4">Wrapped in a <code>&lt;figure&gt;</code> element, no <code>&lt;figcaption&gt;</code>
+              <h4 class="type-4">Plain <code>&lt;img&gt;</code> element</h4>
+              <p class="rs-mb-3"><img src="http://placekitten.com/600/400" alt="Image alt text"></p>
+              <h4 class="type-4">Wrapped in a <code>&lt;figure&gt;</code> element, no <code>&lt;figcaption&gt;</code>
               </h4>
-              <figure class="su-rs-mb-3 su-w-full md:su-w-1/2"><img src="http://placekitten.com/600/400"
+              <figure class="rs-mb-3 w-full md:w-1/2"><img src="http://placekitten.com/600/400"
                   alt="Image alt text"></figure>
-              <h4 class="su-type-4">Wrapped in a <code>&lt;figure&gt;</code> element, with a
+              <h4 class="type-4">Wrapped in a <code>&lt;figure&gt;</code> element, with a
                 <code>&lt;figcaption&gt;</code>
               </h4>
-              <figure class="su-rs-mb-3 su-w-full md:su-w-1/2">
+              <figure class="rs-mb-3 w-full md:w-1/2">
                 <img src="http://placekitten.com/600/400" alt="Image alt text">
                 <figcaption>Here is a caption for this image. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                   Aliquam a mauris in augue cursus finibus. Curabitur hendrerit iaculis lectus, egestas ultricies orci.
@@ -974,58 +974,58 @@ p q r s t u v w x y z { | } ~
               </figure>
             </div>
           </article>
-          <article id="embedded__youtube" class="su-rs-mb-5">
+          <article id="embedded__youtube" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Embed YouTube</h3>
+              <h3 class="type-5 text-lagunita-light">Embed YouTube</h3>
             </header>
-            <div class="su-embed-container"><iframe width="560" height="315"
+            <div class="embed-container"><iframe width="560" height="315"
                 src="https://www.youtube.com/embed/0qHWub21h5c" frameborder="0"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                 allowfullscreen></iframe></div>
           </article>
-          <article id="embedded__audio" class="su-rs-mb-5">
+          <article id="embedded__audio" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Audio</h3>
+              <h3 class="type-5 text-lagunita-light">Audio</h3>
             </header>
             <div><audio controls="">audio</audio></div>
           </article>
-          <article id="embedded__video" class="su-rs-mb-5">
+          <article id="embedded__video" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Video</h3>
+              <h3 class="type-5 text-lagunita-light">Video</h3>
             </header>
             <div><video controls="">video</video></div>
           </article>
-          <article id="text__hr" class="su-rs-mb-5">
+          <article id="text__hr" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Horizontal Rule</h3>
+              <h3 class="type-5 text-lagunita-light">Horizontal Rule</h3>
             </header>
             <div>
               <hr>
             </div>
           </article>
-          <article id="embedded__meter" class="su-rs-mb-5">
+          <article id="embedded__meter" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Meter</h3>
+              <h3 class="type-5 text-lagunita-light">Meter</h3>
             </header>
             <div><meter value="2" min="0" max="10">2 out of 10</meter></div>
           </article>
-          <article id="embedded__progress" class="su-rs-mb-5">
+          <article id="embedded__progress" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Progress</h3>
+              <h3 class="type-5 text-lagunita-light">Progress</h3>
             </header>
             <div><progress value="32" max="100">progress</progress></div>
           </article>
-          <article id="embedded__svg" class="su-rs-mb-5">
+          <article id="embedded__svg" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Inline SVG</h3>
+              <h3 class="type-5 text-lagunita-light">Inline SVG</h3>
             </header>
             <div><svg width="100px" height="100px">
                 <circle cx="100" cy="100" r="100" fill="#1fa3ec"></circle>
               </svg></div>
           </article>
-          <article id="embedded__iframe" class="su-rs-mb-5">
+          <article id="embedded__iframe" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">iframe</h3>
+              <h3 class="type-5 text-lagunita-light">iframe</h3>
             </header>
             <div><iframe src="index.html" height="300" width="100%"></iframe></div>
           </article>
@@ -1033,60 +1033,60 @@ p q r s t u v w x y z { | } ~
       </div>
     </section>
     <!-- Form Elements section -->
-    <section class="su-rs-mb-3">
-      <header id="forms" class="su-rs-py-4 su-bg-black-90">
-        <div class="su-cc">
-          <h2 class="su-type-6 su-text-white su-mb-0 su-text-center">Form Elements</h2>
+    <section class="rs-mb-3">
+      <header id="forms" class="rs-py-4 bg-black-90">
+        <div class="cc">
+          <h2 class="type-6 text-white mb-0 text-center">Form Elements</h2>
         </div>
       </header>
-      <div class="su-cc su-flex su-flex-col md:su-flex-row su-rs-py-6 su-overflow-x-hidden">
-        <div class="su-mx-auto su-w-full lg:su-w-8/12">
+      <div class="cc flex flex-col md:flex-row rs-py-6 overflow-x-hidden">
+        <div class="mx-auto w-full lg:w-8/12">
           <form>
-            <fieldset id="forms__input" class="su-fieldset su-rs-mb-3">
-              <legend class="su-legend">Input fields</legend>
+            <fieldset id="forms__input" class="fieldset rs-mb-3">
+              <legend class="legend">Input fields</legend>
               <p>
-                <label for="input__text" class="su-label">Text Input</label>
-                <input class="su-input" id="input__text" type="text">
+                <label for="input__text" class="label">Text Input</label>
+                <input class="input" id="input__text" type="text">
               </p>
               <p>
-                <label for="input__password" class="su-label">Password</label>
-                <input class="su-input" id="input__password" type="password">
+                <label for="input__password" class="label">Password</label>
+                <input class="input" id="input__password" type="password">
               </p>
               <p>
-                <label for="input__webaddress" class="su-label">Web Address</label>
-                <input class="su-input" id="input__webaddress" type="url">
+                <label for="input__webaddress" class="label">Web Address</label>
+                <input class="input" id="input__webaddress" type="url">
               </p>
               <p>
-                <label for="input__emailaddress" class="su-label">Email Address</label>
-                <input class="su-input" id="input__emailaddress" type="email">
+                <label for="input__emailaddress" class="label">Email Address</label>
+                <input class="input" id="input__emailaddress" type="email">
               </p>
               <p>
-                <label for="input__phone" class="su-label">Phone Number</label>
-                <input class="su-input" id="input__phone" type="tel">
+                <label for="input__phone" class="label">Phone Number</label>
+                <input class="input" id="input__phone" type="tel">
               </p>
               <p>
-                <label for="input__search" class="su-label">Search</label>
-                <input class="su-input" id="input__search" type="search">
+                <label for="input__search" class="label">Search</label>
+                <input class="input" id="input__search" type="search">
               </p>
               <p>
-                <label for="input__text2" class="su-label">Number Input</label>
-                <input class="su-input" id="input__text2" type="number">
+                <label for="input__text2" class="label">Number Input</label>
+                <input class="input" id="input__text2" type="number">
               </p>
               <p>
-                <label for="input__text3" class="su-label error">Error</label>
-                <input class="su-input is-error" id="input__text3" type="text">
+                <label for="input__text3" class="label error">Error</label>
+                <input class="input is-error" id="input__text3" type="text">
               </p>
               <p>
-                <label for="input__text4" class="su-label valid">Valid</label>
-                <input class="su-input is-valid" id="input__text4" type="text">
+                <label for="input__text4" class="label valid">Valid</label>
+                <input class="input is-valid" id="input__text4" type="text">
               </p>
             </fieldset>
 
-            <fieldset id="forms__select" class="su-fieldset su-rs-mb-3">
-              <legend class="su-legend">Select menus</legend>
+            <fieldset id="forms__select" class="fieldset rs-mb-3">
+              <legend class="legend">Select menus</legend>
               <p>
-                <label for="select" class="su-label">Select</label>
-                <select class="su-select" id="select">
+                <label for="select" class="label">Select</label>
+                <select class="select" id="select">
                   <optgroup label="Option Group">
                     <option>Option One</option>
                     <option>Option Two</option>
@@ -1096,92 +1096,92 @@ p q r s t u v w x y z { | } ~
               </p>
             </fieldset>
 
-            <fieldset id="forms__checkbox" class="su-fieldset su-rs-mb-3">
-              <legend class="su-legend">Checkboxes</legend>
+            <fieldset id="forms__checkbox" class="fieldset rs-mb-3">
+              <legend class="legend">Checkboxes</legend>
               <ul>
-                <li><input class="su-checkbox" id="checkbox1" name="checkbox" type="checkbox" checked="checked" /><label
-                    class="su-label" for="checkbox1">Choice A</label></li>
-                <li><input class="su-checkbox" id="checkbox2" name="checkbox" type="checkbox" /><label class="su-label"
+                <li><input class="checkbox" id="checkbox1" name="checkbox" type="checkbox" checked="checked" /><label
+                    class="label" for="checkbox1">Choice A</label></li>
+                <li><input class="checkbox" id="checkbox2" name="checkbox" type="checkbox" /><label class="label"
                     for="checkbox2">Choice B</label></li>
-                <li><input class="su-checkbox" id="checkbox3" name="checkbox" type="checkbox" /><label class="su-label"
+                <li><input class="checkbox" id="checkbox3" name="checkbox" type="checkbox" /><label class="label"
                     for="checkbox3">Choice C</label></li>
-                <li><input class="su-checkbox" id="checkbox4" name="checkbox" type="checkbox" /><label class="su-label"
+                <li><input class="checkbox" id="checkbox4" name="checkbox" type="checkbox" /><label class="label"
                     for="checkbox3">Choice D</label></li>
               </ul>
             </fieldset>
 
-            <fieldset id="forms__radio" class="su-fieldset su-rs-mb-3">
-              <legend class="su-legend">Radio buttons</legend>
+            <fieldset id="forms__radio" class="fieldset rs-mb-3">
+              <legend class="legend">Radio buttons</legend>
               <ul>
-                <li><input class="su-radio" id="radio1" name="radio" type="radio" class="radio"
-                    checked="checked" /><label class="su-label" for="radio1">Option 1</label></li>
-                <li><input class="su-radio" id="radio2" name="radio" type="radio" class="radio" /><label
-                    class="su-label" for="radio2">Option 2</label>
+                <li><input class="radio" id="radio1" name="radio" type="radio" class="radio"
+                    checked="checked" /><label class="label" for="radio1">Option 1</label></li>
+                <li><input class="radio" id="radio2" name="radio" type="radio" class="radio" /><label
+                    class="label" for="radio2">Option 2</label>
                 </li>
-                <li><input class="su-radio" id="radio3" name="radio" type="radio" class="radio" /><label
-                    class="su-label" for="radio3">Option 3</label>
+                <li><input class="radio" id="radio3" name="radio" type="radio" class="radio" /><label
+                    class="label" for="radio3">Option 3</label>
                 </li>
               </ul>
             </fieldset>
 
-            <fieldset id="forms__textareas" class="su-fieldset su-rs-mb-3">
-              <legend class="su-legend">Textareas</legend>
+            <fieldset id="forms__textareas" class="fieldset rs-mb-3">
+              <legend class="legend">Textareas</legend>
               <p>
-                <label class="su-label" for="textarea">Textarea</label>
+                <label class="label" for="textarea">Textarea</label>
                 <textarea id="textarea" rows="8" cols="48" placeholder="Enter your message here"
-                  class="su-textarea"></textarea>
+                  class="textarea"></textarea>
               </p>
             </fieldset>
 
-            <fieldset id="forms__html5" class="su-fieldset su-rs-mb-3">
-              <legend class="su-legend">HTML5 inputs</legend>
+            <fieldset id="forms__html5" class="fieldset rs-mb-3">
+              <legend class="legend">HTML5 inputs</legend>
               <p>
-                <label class="su-label" for="ic">Color input</label>
-                <input class="su-input" type="color" id="ic" value="#000000">
+                <label class="label" for="ic">Color input</label>
+                <input class="input" type="color" id="ic" value="#000000">
               </p>
               <p>
-                <label class="su-label" for="in">Number input</label>
-                <input class="su-input" type="number" id="in" min="0" max="10" value="5">
+                <label class="label" for="in">Number input</label>
+                <input class="input" type="number" id="in" min="0" max="10" value="5">
               </p>
               <p>
-                <label class="su-label" for="ir">Range input</label>
-                <input class="su-input" type="range" id="ir" value="10">
+                <label class="label" for="ir">Range input</label>
+                <input class="input" type="range" id="ir" value="10">
               </p>
               <p>
-                <label class="su-label" for="idd">Date input</label>
-                <input class="su-input" type="date" id="idd" value="1970-01-01">
+                <label class="label" for="idd">Date input</label>
+                <input class="input" type="date" id="idd" value="1970-01-01">
               </p>
               <p>
-                <label class="su-label" for="idm">Month input</label>
-                <input class="su-input" type="month" id="idm" value="1970-01">
+                <label class="label" for="idm">Month input</label>
+                <input class="input" type="month" id="idm" value="1970-01">
               </p>
               <p>
-                <label class="su-label" for="idw">Week input</label>
-                <input class="su-input" type="week" id="idw" value="1970-W01">
+                <label class="label" for="idw">Week input</label>
+                <input class="input" type="week" id="idw" value="1970-W01">
               </p>
               <p>
-                <label class="su-label" for="idt">Datetime input</label>
-                <input class="su-input" type="datetime" id="idt" value="1970-01-01T00:00:00Z">
+                <label class="label" for="idt">Datetime input</label>
+                <input class="input" type="datetime" id="idt" value="1970-01-01T00:00:00Z">
               </p>
               <p>
-                <label class="su-label" for="idtl">Datetime-local input</label>
-                <input class="su-input" type="datetime-local" id="idtl" value="1970-01-01T00:00">
+                <label class="label" for="idtl">Datetime-local input</label>
+                <input class="input" type="datetime-local" id="idtl" value="1970-01-01T00:00">
               </p>
             </fieldset>
 
-            <fieldset id="forms__action" class="su-fieldset su-rs-mb-3">
-              <legend class="su-legend">Action buttons</legend>
+            <fieldset id="forms__action" class="fieldset rs-mb-3">
+              <legend class="legend">Action buttons</legend>
               <p>
-                <input class="su-button" type="submit" value="<input type=submit>">
-                <input class="su-button" type="button" value="<input type=button>">
-                <input class="su-button" type="reset" value="<input type=reset>">
-                <input class="su-button" type="submit" value="<input disabled>" disabled>
+                <input class="button" type="submit" value="<input type=submit>">
+                <input class="button" type="button" value="<input type=button>">
+                <input class="button" type="reset" value="<input type=reset>">
+                <input class="button" type="submit" value="<input disabled>" disabled>
               </p>
               <p>
-                <button class="su-button" type="submit">&lt;button type=submit&gt;</button>
-                <button class="su-button" type="button">&lt;button type=button&gt;</button>
-                <button class="su-button" type="reset">&lt;button type=reset&gt;</button>
-                <button class="su-button" type="button" disabled>&lt;button disabled&gt;</button>
+                <button class="button" type="submit">&lt;button type=submit&gt;</button>
+                <button class="button" type="button">&lt;button type=button&gt;</button>
+                <button class="button" type="reset">&lt;button type=reset&gt;</button>
+                <button class="button" type="button" disabled>&lt;button disabled&gt;</button>
               </p>
             </fieldset>
           </form>
@@ -1189,104 +1189,104 @@ p q r s t u v w x y z { | } ~
       </div>
     </section>
     <!-- Layouts section -->
-    <section class="su-rs-mb-3">
-      <header id="layouts" class="su-rs-py-4 su-bg-black-90">
-        <div class="su-cc">
-          <h2 class="su-type-6 su-text-white su-mb-0 su-text-center">Layouts and Grids</h2>
+    <section class="rs-mb-3">
+      <header id="layouts" class="rs-py-4 bg-black-90">
+        <div class="cc">
+          <h2 class="type-6 text-white mb-0 text-center">Layouts and Grids</h2>
         </div>
       </header>
-      <div class="su-cc su-flex su-flex-col md:su-flex-row su-rs-py-6">
-        <div class="su-mx-auto su-w-full">
-          <article id="css-grid" class="su-rs-mb-5">
+      <div class="cc flex flex-col md:flex-row rs-py-6">
+        <div class="mx-auto w-full">
+          <article id="css-grid" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">CSS Grid</h3>
+              <h3 class="type-5 text-lagunita-light">CSS Grid</h3>
             </header>
             <div class="overflow-hidden">
-              <div class="su-grid su-grid-cols-3 su-grid-gap">
-                <div class="su-bg-sky-light su-flex su-justify-center su-items-center su-rs-p-3 su-type-3 su-font-bold">
+              <div class="grid grid-cols-3 grid-gap">
+                <div class="bg-sky-light flex justify-center items-center rs-p-3 type-3 font-bold">
                   1</div>
-                <div class="su-bg-sky-light su-flex su-justify-center su-items-center su-rs-p-3 su-type-3 su-font-bold">
+                <div class="bg-sky-light flex justify-center items-center rs-p-3 type-3 font-bold">
                   2</div>
-                <div class="su-bg-sky-light su-flex su-justify-center su-items-center su-rs-p-3 su-type-3 su-font-bold">
+                <div class="bg-sky-light flex justify-center items-center rs-p-3 type-3 font-bold">
                   3</div>
                 <div
-                  class="su-col-span-2 su-bg-sky-dark su-text-white su-flex su-justify-center su-items-center su-rs-p-3 su-type-3 su-font-bold">
+                  class="col-span-2 bg-sky-dark text-white flex justify-center items-center rs-p-3 type-3 font-bold">
                   4</div>
-                <div class="su-bg-sky-light su-flex su-justify-center su-items-center su-rs-p-3 su-type-3 su-font-bold">
+                <div class="bg-sky-light flex justify-center items-center rs-p-3 type-3 font-bold">
                   5</div>
-                <div class="su-bg-sky-light su-flex su-justify-center su-items-center su-rs-p-3 su-type-3 su-font-bold">
+                <div class="bg-sky-light flex justify-center items-center rs-p-3 type-3 font-bold">
                   6</div>
                 <div
-                  class="su-col-span-2 su-bg-sky-dark su-text-white su-flex su-justify-center su-items-center su-rs-p-3 su-type-3 su-font-bold">
+                  class="col-span-2 bg-sky-dark text-white flex justify-center items-center rs-p-3 type-3 font-bold">
                   7</div>
                 <div
-                  class="su-col-span-3 su-bg-sky su-text-white su-flex su-justify-center su-items-center su-rs-p-3 su-type-3 su-font-bold">
+                  class="col-span-3 bg-sky text-white flex justify-center items-center rs-p-3 type-3 font-bold">
                   8</div>
               </div>
             </div>
           </article>
-          <article id="flex-grid" class="su-rs-mb-5">
+          <article id="flex-grid" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Flex Grid</h3>
+              <h3 class="type-5 text-lagunita-light">Flex Grid</h3>
             </header>
             <div
-              class="su-flex su-flex-col md:su-flex-row su-gap-xs lg:su-gap-lg xl:su-gap-xl 2xl:su-gap-2xl su-text-white su-rs-mb-2">
-              <div class="su-w-full md:su-w-1/2 su-bg-palo-verde-light su-rs-p-2">
+              class="flex flex-col md:flex-row gap-xs lg:gap-lg xl:gap-xl 2xl:gap-2xl text-white rs-mb-2">
+              <div class="w-full md:w-1/2 bg-palo-verde-light rs-p-2">
                 <h3>6 of 12 columns</h3>
-                <p class="su-card-paragraph">This column stacks vertically for XS-SM breakpoints and spans 6 of 12
+                <p class="card-paragraph">This column stacks vertically for XS-SM breakpoints and spans 6 of 12
                   columns for MD and up; responsive grid gaps.</p>
               </div>
-              <div class="su-w-full md:su-w-1/2 su-bg-palo-verde-dark su-rs-p-2">
+              <div class="w-full md:w-1/2 bg-palo-verde-dark rs-p-2">
                 <h3>6 of 12 columns</h3>
-                <p class="su-card-paragraph">This column stacks vertically for XS-SM breakpoints and spans 6 of 12
+                <p class="card-paragraph">This column stacks vertically for XS-SM breakpoints and spans 6 of 12
                   columns for MD and up; responsive grid gaps.</p>
               </div>
             </div>
-            <div class="su-flex su-flex-col sm:su-flex-row su-grid-gap su-rs-mb-2 su-text-white">
-              <div class="su-w-full sm:su-w-1/2 lg:su-w-3/4 su-bg-spirited su-rs-p-2">
+            <div class="flex flex-col sm:flex-row grid-gap rs-mb-2 text-white">
+              <div class="w-full sm:w-1/2 lg:w-3/4 bg-spirited rs-p-2">
                 <h3>8 of 12 columns</h3>
-                <p class="su-card-paragraph">This column stacks vertically for XS breakpoint; spans 6 of 12 columns for
-                  SM-MD; spans 8 of 12 columns for LG and up; responsive column gaps using .su-grid-gap class.</p>
+                <p class="card-paragraph">This column stacks vertically for XS breakpoint; spans 6 of 12 columns for
+                  SM-MD; spans 8 of 12 columns for LG and up; responsive column gaps using .grid-gap class.</p>
               </div>
-              <div class="su-w-full sm:su-w-1/2 lg:su-w-1/4 su-bg-spirited-dark su-rs-p-2">
+              <div class="w-full sm:w-1/2 lg:w-1/4 bg-spirited-dark rs-p-2">
                 <h3>4 of 12 columns</h3>
-                <p class="su-card-paragraph">This column stacks vertically for XS breakpoint; spans 6 of 12 columns for
-                  SM-MD; spans 4 of 12 columns for LG and up; responsive column gaps using .su-grid-gap class.</p>
+                <p class="card-paragraph">This column stacks vertically for XS breakpoint; spans 6 of 12 columns for
+                  SM-MD; spans 4 of 12 columns for LG and up; responsive column gaps using .grid-gap class.</p>
               </div>
             </div>
           </article>
-          <article id="aspect-ratio" class="su-rs-mb-5">
+          <article id="aspect-ratio" class="rs-mb-5">
             <header>
-              <h3 class="su-type-5 su-text-lagunita-light">Aspect Ratio Containers</h3>
+              <h3 class="type-5 text-lagunita-light">Aspect Ratio Containers</h3>
             </header>
             <p>Note: The aspect ratio classes have to be added to a wrapper container around your element. To use a
               width decorator class, you'll need to add a parent container that wraps around your aspect ratio
               container. Below are a few commonly used ones.</p>
-            <div class="su-w-full md:su-w-1/3 su-rs-mb-2">
-              <div class="su-aspect-w-1 su-aspect-h-1 su-bg-illuminating-dark su-text-black">
-                <div class="su-rs-p-4 su-grid su-justify-center su-content-center">
-                  <h3 class="su-mb-0">Square</h3>
+            <div class="w-full md:w-1/3 rs-mb-2">
+              <div class="aspect-w-1 aspect-h-1 bg-illuminating-dark text-black">
+                <div class="rs-p-4 grid justify-center content-center">
+                  <h3 class="mb-0">Square</h3>
                 </div>
               </div>
             </div>
-            <div class="su-w-full md:su-w-1/3 su-rs-mb-2">
-              <div class="su-aspect-w-4 su-aspect-h-3 su-bg-plum-light su-text-white">
-                <div class="su-rs-p-4 su-grid su-justify-center su-content-center">
-                  <h3 class="su-mb-0">4 x 3 Box</h3>
+            <div class="w-full md:w-1/3 rs-mb-2">
+              <div class="aspect-w-4 aspect-h-3 bg-plum-light text-white">
+                <div class="rs-p-4 grid justify-center content-center">
+                  <h3 class="mb-0">4 x 3 Box</h3>
                 </div>
               </div>
             </div>
-            <div class="su-w-full md:su-w-1/2 su-rs-mb-2">
-              <div class="su-aspect-w-16 su-aspect-h-9 su-bg-bay-dark su-text-white">
-                <div class="su-rs-p-4 su-grid su-justify-center su-content-center">
-                  <h3 class="su-mb-0">16 x 9 Box</h3>
+            <div class="w-full md:w-1/2 rs-mb-2">
+              <div class="aspect-w-16 aspect-h-9 bg-bay-dark text-white">
+                <div class="rs-p-4 grid justify-center content-center">
+                  <h3 class="mb-0">16 x 9 Box</h3>
                 </div>
               </div>
             </div>
-            <div class="su-w-full md:su-w-1/2 su-rs-mb-2">
-              <div class="su-aspect-w-2 su-aspect-h-1 su-bg-poppy-dark su-text-white">
-                <div class="su-rs-p-4 su-grid su-justify-center su-content-center">
-                  <h3 class="su-mb-0">2 x 1 Box</h3>
+            <div class="w-full md:w-1/2 rs-mb-2">
+              <div class="aspect-w-2 aspect-h-1 bg-poppy-dark text-white">
+                <div class="rs-p-4 grid justify-center content-center">
+                  <h3 class="mb-0">2 x 1 Box</h3>
                 </div>
               </div>
             </div>
@@ -1297,101 +1297,101 @@ p q r s t u v w x y z { | } ~
 
   </main>
   <div
-    class='su-global-footer su-basefont-21 su-bg-digital-red su-rs-py-1 su-text-white su-link-white'>
-    <div class='su-cc su-flex su-flex-col lg:su-flex-row' title='Common Stanford resources'>
-      <div class='su-text-center su-mt-5 su-mb-9'>
-        <a class='su-logo su-type-3 hocus:su-text-white' href='https://www.stanford.edu'>Stanford<br />University</a>
+    class='global-footer basefont-21 bg-digital-red rs-py-1 text-white link-white'>
+    <div class='cc flex flex-col lg:flex-row' title='Common Stanford resources'>
+      <div class='text-center mt-5 mb-9'>
+        <a class='logo type-3 hocus:text-white' href='https://www.stanford.edu'>Stanford<br />University</a>
       </div>
-      <div class='lg:su-pl-45 xl:su-pl-50 su-text-left sm:su-text-center lg:su-text-left su-flex-grow'>
+      <div class='lg:pl-45 xl:pl-50 text-left sm:text-center lg:text-left flex-grow'>
         <nav aria-label='global footer menu'
-          class='su-flex su-flex-row sm:su-flex-col su-justify-center sm:su-items-center lg:su-items-start su-mb-10 su-link-no-underline'>
+          class='flex flex-row sm:flex-col justify-center sm:items-center lg:items-start mb-10 link-no-underline'>
           <ul
-            class='su-list-unstyled su-mb-10 sm:su-mb-4 su-mr-19 sm:su-mr-0 su-p-0 su-text-15 md:su-text-17 2xl:su-text-18 su-flex su-flex-col sm:su-flex-row'>
-            <li class="sm:su-mr-10 md:su-mr-20 lg:su-mr-27">
-              <a href='https://www.stanford.edu' class='hover:su-underline focus:su-underline'>
+            class='list-unstyled mb-10 sm:mb-4 mr-19 sm:mr-0 p-0 text-15 md:text-17 2xl:text-18 flex flex-col sm:flex-row'>
+            <li class="sm:mr-10 md:mr-20 lg:mr-27">
+              <a href='https://www.stanford.edu' class='hover:underline focus:underline'>
                 Stanford Home
-                <span class="su-sr-only">(link is external)</span>
+                <span class="sr-only">(link is external)</span>
               </a>
             </li>
-            <li class="sm:su-mr-10 md:su-mr-20 lg:su-mr-27">
-              <a href='https://visit.stanford.edu/plan/' class='hover:su-underline focus:su-underline'>
+            <li class="sm:mr-10 md:mr-20 lg:mr-27">
+              <a href='https://visit.stanford.edu/plan/' class='hover:underline focus:underline'>
                 Maps &amp; Directions
-                <span class="su-sr-only">(link is external)</span>
+                <span class="sr-only">(link is external)</span>
               </a>
             </li>
-            <li class="sm:su-mr-10 md:su-mr-20 lg:su-mr-27">
-              <a href='https://www.stanford.edu/search/' class='hover:su-underline focus:su-underline'>
+            <li class="sm:mr-10 md:mr-20 lg:mr-27">
+              <a href='https://www.stanford.edu/search/' class='hover:underline focus:underline'>
                 Search Stanford
-                <span class="su-sr-only">(link is external)</span>
+                <span class="sr-only">(link is external)</span>
               </a>
             </li>
             <li>
-              <a href='https://emergency.stanford.edu' class='hover:su-underline focus:su-underline'>
+              <a href='https://emergency.stanford.edu' class='hover:underline focus:underline'>
                 Emergency Info
-                <span class="su-sr-only">(link is external)</span>
+                <span class="sr-only">(link is external)</span>
               </a>
             </li>
           </ul>
           <ul
-            class='su-list-unstyled su-mb-10 sm:su-mb-0 su-ml-19 sm:su-ml-0 su-p-0 su-text-15 sm:su-text-14 md:su-text-15 xl:su-text-16 su-flex su-flex-col sm:su-flex-row sm:su-link-regular'>
-            <li class="sm:su-mr-10 md:su-mr-20 lg:su-mr-27">
-              <a href='https://www.stanford.edu/site/terms/' title='Terms of use for sites' class='hover:su-underline focus:su-underline'>
+            class='list-unstyled mb-10 sm:mb-0 ml-19 sm:ml-0 p-0 text-15 sm:text-14 md:text-15 xl:text-16 flex flex-col sm:flex-row sm:link-regular'>
+            <li class="sm:mr-10 md:mr-20 lg:mr-27">
+              <a href='https://www.stanford.edu/site/terms/' title='Terms of use for sites' class='hover:underline focus:underline'>
                 Terms of Use
-                <span class="su-sr-only">(link is external)</span>
+                <span class="sr-only">(link is external)</span>
               </a>
             </li>
-            <li class="sm:su-mr-10 md:su-mr-20 lg:su-mr-27">
-              <a href='https://www.stanford.edu/site/privacy/' title='Privacy and cookie policy' class='hover:su-underline focus:su-underline'>
+            <li class="sm:mr-10 md:mr-20 lg:mr-27">
+              <a href='https://www.stanford.edu/site/privacy/' title='Privacy and cookie policy' class='hover:underline focus:underline'>
                 Privacy
-                <span class="su-sr-only">(link is external)</span>
+                <span class="sr-only">(link is external)</span>
               </a>
             </li>
-            <li class="sm:su-mr-10 md:su-mr-20 lg:su-mr-27">
+            <li class="sm:mr-10 md:mr-20 lg:mr-27">
               <a href='https://uit.stanford.edu/security/copyright-infringement'
-                title='Report alleged copyright infringement' class='hover:su-underline focus:su-underline'>
+                title='Report alleged copyright infringement' class='hover:underline focus:underline'>
                 Copyright
-                <span class="su-sr-only">(link is external)</span>
+                <span class="sr-only">(link is external)</span>
               </a>
             </li>
-            <li class="sm:su-mr-10 md:su-mr-20 lg:su-mr-27">
+            <li class="sm:mr-10 md:mr-20 lg:mr-27">
               <a href='https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4'
-                title='Ownership and use of Stanford trademarks and images' class='hover:su-underline focus:su-underline'>
+                title='Ownership and use of Stanford trademarks and images' class='hover:underline focus:underline'>
                 Trademarks
-                <span class="su-sr-only">(link is external)</span>
+                <span class="sr-only">(link is external)</span>
               </a>
             </li>
-            <li class="sm:su-mr-10 md:su-mr-20 lg:su-mr-27">
-              <a href='http://exploredegrees.stanford.edu/nonacademicregulations/nondiscrimination/'
-                title='Non-discrimination policy' class='hover:su-underline focus:su-underline'>
+            <li class="sm:mr-10 md:mr-20 lg:mr-27">
+              <a href='https://studentservices.stanford.edu/more-resources/student-policies/non-academic/non-discrimination'
+                title='Non-discrimination policy' class='hover:underline focus:underline'>
                 Non-Discrimination
-                <span class="su-sr-only">(link is external)</span>
+                <span class="sr-only">(link is external)</span>
               </a>
             </li>
             <li>
-              <a href='https://www.stanford.edu/site/accessibility' title='Report web accessibility issues' class='hover:su-underline focus:su-underline'>
+              <a href='https://www.stanford.edu/site/accessibility' title='Report web accessibility issues' class='hover:underline focus:underline'>
                 Accessibility
-                <span class="su-sr-only">(link is external)</span>
+                <span class="sr-only">(link is external)</span>
               </a>
             </li>
           </ul>
         </nav>
-        <div class='su-text-13 sm:su-text-14 su-text-center lg:su-text-left'>
-          <span class="su-whitespace-no-wrap">&copy; Stanford University.</span>
-          <span class="su-whitespace-no-wrap">&nbsp; Stanford, California 94305.</span>
+        <div class='text-13 sm:text-14 text-center lg:text-left'>
+          <span class="whitespace-no-wrap">&copy; Stanford University.</span>
+          <span class="whitespace-no-wrap">&nbsp; Stanford, California 94305.</span>
         </div>
       </div>
     </div>
   </div>
-  <footer role="contentinfo" class="su-bg-black su-text-white su-text-16 md:su-text-18 su-rs-py-2">
+  <footer role="contentinfo" class="bg-black text-white text-16 md:text-18 rs-py-2">
     <!-- HTML Test page based on sample provided by http://twitter.com/cbracco -->
-    <div class="su-cc">
-      <p class="su-mb-0">A TailwindCSS/Decanter v7 test page.</p>
+    <div class="cc">
+      <p class="mb-0">A TailwindCSS/Decanter v7 test page.</p>
       <p><a href="https://www.netlify.com"><img src="https://www.netlify.com/img/global/badges/netlify-dark.svg"></a>
       </p>
     </div>
     <a href="#top"
-      class="su-hidden md:su-block su-fixed su-bottom-20 su-right-20 su-w-50 su-text-black hocus:su-text-plum su-transition-colors"><span
-        class="su-sr-only">Back to top</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"
+      class="hidden md:block fixed bottom-20 right-20 w-50 text-black hocus:text-plum transition-colors"><span
+        class="sr-only">Back to top</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"
         fill="currentColor">
         <path fill-rule="evenodd"
           d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,9 +10,6 @@ const plugin = require('tailwindcss/plugin');
 const dir = path.resolve(__dirname, 'src/plugins');
 
 module.exports = {
-  // Our own prefix.
-  prefix: 'su-',
-
   // The theme section is where you define your color palette, font stacks,
   // type scale, border sizes, breakpoints — anything related to the visual
   // design of your site.
@@ -54,6 +51,10 @@ module.exports = {
       ]);
       addVariant('group-hocus-visible', [
         ':merge(.group):focus-visible &',
+        ':merge(.group):hover &',
+      ]);
+      addVariant('group-hocus-within', [
+        ':merge(.group):focus-within &',
         ':merge(.group):hover &',
       ]);
       addVariant('children', '& > *');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove the `su-` prefix due to popular demand
- Update TW theme fontFamily to use Source Sans 3 and Source Serif 4. Leaving Source Sans Pro and Source Serif Pro as 2nd in lines for fallback for now to support incremental update of projects
- Add `group-hocus-within`: variant (`group-hover:` + `group-focus-within:`)
- TW version and other dependencies update
- Update preview site and docs to remove `su-` prefix


# Steps to Test

1. Look at the preview and see that it functions and looks the same; inspect to see that the TW classes now has no su- prefix
2. Look at code
3. Look at things called out



# Associated Issues and/or People
- This is related to the UComm announcement about the font change
