### PR TITLE
D8CORE-6896: changed non descrimination link and added nofollow to href

### DIFF
--- a/core/src/templates/components/global-footer/global-footer.twig
+++ b/core/src/templates/components/global-footer/global-footer.twig
@@ -25,23 +25,23 @@
     <div class="su-global-footer__content">
       <nav aria-label="global footer menu">
         <ul class="su-global-footer__menu su-global-footer__menu--global">
-          <li><a href="https://www.stanford.edu">Stanford Home{{ external_link_text }}</a></li>
-          <li><a href="https://visit.stanford.edu/basics/">Maps &amp; Directions{{ external_link_text }}</a></li>
-          <li><a href="https://www.stanford.edu/search/">Search Stanford{{ external_link_text }}</a></li>
-          <li><a href="https://emergency.stanford.edu">Emergency Info{{ external_link_text }}</a></li>
+          <li><a href="https://www.stanford.edu" rel="nofollow">Stanford Home{{ external_link_text }}</a></li>
+          <li><a href="https://visit.stanford.edu/basics/" rel="nofollow">Maps &amp; Directions{{ external_link_text }}</a></li>
+          <li><a href="https://www.stanford.edu/search/" rel="nofollow">Search Stanford{{ external_link_text }}</a></li>
+          <li><a href="https://emergency.stanford.edu" rel="nofollow">Emergency Info{{ external_link_text }}</a></li>
         </ul>
         <ul class="su-global-footer__menu su-global-footer__menu--policy">
-          <li><a href="https://www.stanford.edu/site/terms/"
+          <li><a href="https://www.stanford.edu/site/terms/" rel="nofollow"
                  title="Terms of use for sites">Terms of Use{{ external_link_text }}</a></li>
-          <li><a href="https://www.stanford.edu/site/privacy/"
+          <li><a href="https://www.stanford.edu/site/privacy/" rel="nofollow"
                  title="Privacy and cookie policy">Privacy{{ external_link_text }}</a></li>
-          <li><a href="https://uit.stanford.edu/security/copyright-infringement"
+          <li><a href="https://uit.stanford.edu/security/copyright-infringement" rel="nofollow"
                  title="Report alleged copyright infringement">Copyright{{ external_link_text }}</a></li>
-          <li><a href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4"
+          <li><a href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4" rel="nofollow"
                  title="Ownership and use of Stanford trademarks and images">Trademarks{{ external_link_text }}</a></li>
-          <li><a href="https://studentservices.stanford.edu/more-resources/student-policies/non-academic/non-discrimination"
+          <li><a href="https://non-discrimination.stanford.edu/" rel="nofollow"
                  title="Non-discrimination policy">Non-Discrimination{{ external_link_text }}</a></li>
-          <li><a href="https://www.stanford.edu/site/accessibility"
+          <li><a href="https://www.stanford.edu/site/accessibility" rel="nofollow"
                  title="Report web accessibility issues">Accessibility{{ external_link_text }}</a></li>
         </ul>
       </nav>


### PR DESCRIPTION
# READY FOR REVIEW/NOT READY

# Summary
- Changed the Non-Discrimination link to https://non-discrimination.stanford.edu/
- Added `rel=nofollow` to the `href`s in the footer

# Needed By (Date)
- 9/6

# Urgency
- normal

# Steps to Test

1. Checkout this branch.
2. Verify the link is correct and working.
3. Verify there are now the `rel=nofollow` in the hrefs
4. Verify all links work.


# Affected Projects or Products
- Decanter v6 so far. It will need to be added to v7 as well.

# Associated Issues and/or People
[- D8CORE-6896](https://stanfordits.atlassian.net/browse/D8CORE-6896)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
