### PR TITLE
HSTS set max-age to 31536000

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,5 +20,5 @@
     Content-Security-Policy = "form-action https:"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "origin-when-cross-origin"
-    Strict-Transport-Security = "max-age=2592000"
+    Strict-Transport-Security = "max-age=31536000"
     Permissions-Policy = "vibrate=(), geolocation=(), midi=(), notifications=(), push=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=()"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Sets max age to 31536000
- See: https://github.com/SU-SWS/ood_giving_site/pull/402

# Review By (Date)
- End of the month (march)

# Criticality
- low

# Review Tasks

1. Review preview build headers and look for: `Strict-Transport-Security: max-age=31536000;` in the response headers

