### PR TITLE
Font size utilities deprecation; update documentation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -71,6 +71,8 @@ Migrating now makes the v8 upgrade a no-op.
 | Social brand colors (`facebook`, `twitter`, `instagram`, `linkedin`, `youtube`) | Use the square bracket notation | Yes |
 | Color `foggy` | `fog` (identical color) | Yes |
 | `rs-m-neg1`, `rs-p-neg2` and the other negative responsive spacing steps | Breakpoint modifiers, e.g. `rs-m-neg1` → `p-11 md:p-12 2xl:p-13`, `rs-p-neg2` → `p-8 md:p-9 2xl:p-10` | Yes |
+| `text-m0` – `text-m9` | `type-0` – `type-9` (includes responsive font sizes and letter spacing adjustments), or the exact equivalent arbitrary value such as `text-[1.25em]` | Yes |
+| `text-09em`, `-text-m1` | `text-[.9em]` | Yes |
 
 Two notes on the replacements:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -67,6 +67,7 @@ Migrating now makes the v8 upgrade a no-op.
 | `.text-vertical-lr` | `[writing-mode:vertical-lr]` | Yes |
 | `font-regular` | `font-normal` | Yes |
 | `font-slab` | Leave alone now and update when v8 is out | Yes |
+| The `Source Sans Pro` / `Source Serif Pro` fallbacks in `font-sans` / `font-serif` | Make sure Source Sans 3 and Source Serif 4 are loaded — see the note below | Yes |
 | `font-mono` | Leave alone now and update when v8 is out | Yes |
 | Social brand colors (`facebook`, `twitter`, `instagram`, `linkedin`, `youtube`) | Use the square bracket notation | Yes |
 | Color `foggy` | `fog` (identical color) | Yes |
@@ -74,7 +75,15 @@ Migrating now makes the v8 upgrade a no-op.
 | `text-m0` – `text-m9` | `type-0` – `type-9` (includes responsive font sizes and letter spacing adjustments), or the exact equivalent arbitrary value such as `text-[1.25em]` | Yes |
 | `text-09em`, `-text-m1` | `text-[.9em]` | Yes |
 
-Two notes on the replacements:
+Three notes on the replacements:
+
+- **The Pro font fallbacks are inert for most projects.** `font-sans` and `font-serif`
+  keep leading with Source Sans 3 and Source Serif 4; v8 only drops the superseded
+  `Source Sans Pro` / `Source Serif Pro` entry sitting behind each. Decanter's
+  `fonts.css` and `fonts-basic.css` load only Source Sans 3 and Source Serif 4, so
+  those entries never match unless you load the Pro families yourself. If you do, or
+  you depend on them being installed locally, ensure Source Sans 3 and Source Serif 4
+  are available — otherwise text falls through to Helvetica Neue and Georgia.
 
 - **`.credits` is being removed for accessibility reasons** — small italic text is not
   recommended. The replacement above reproduces the v7 styling if you need it, but

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -72,10 +72,28 @@ Migrating now makes the v8 upgrade a no-op.
 | Social brand colors (`facebook`, `twitter`, `instagram`, `linkedin`, `youtube`) | Use the square bracket notation | Yes |
 | Color `foggy` | `fog` (identical color) | Yes |
 | `rs-m-neg1`, `rs-p-neg2` and the other negative responsive spacing steps | Breakpoint modifiers, e.g. `rs-m-neg1` → `p-11 md:p-12 2xl:p-13`, `rs-p-neg2` → `p-8 md:p-9 2xl:p-10` | Yes |
-| `text-m0` – `text-m9` | `type-0` – `type-9` (includes responsive font sizes and letter spacing adjustments), or the exact equivalent arbitrary value such as `text-[1.25em]` | Yes |
-| `text-09em`, `-text-m1` | `text-[.9em]` | Yes |
+| `text-m0` | `type-0`, or `text-[1em]` | Yes |
+| `text-m1` | `type-1`, or `text-[1.25em]` | Yes |
+| `text-m2` | `type-2`, or `text-[1.56em]` | Yes |
+| `text-m3` | `type-3`, or `text-[1.95em]` | Yes |
+| `text-m4` | `type-4`, or `text-[2.44em]` | Yes |
+| `text-m5` | `type-5`, or `text-[3.05em]` | Yes |
+| `text-m6` | `type-6`, or `text-[3.81em]` | Yes |
+| `text-m7` | `type-7`, or `text-[4.77em]` | Yes |
+| `text-m8` | `type-8`, or `text-[5.96em]` | Yes |
+| `text-m9` | `type-9`, or `text-[7.45em]` | Yes |
+| `text-09em`, `-text-m1` | `text-[.9em]` (no `type-*` equivalent — the 0.9em step is not on the scale) | Yes |
 
-Three notes on the replacements:
+Four notes on the replacements:
+
+- **The two font size replacements are not equivalent — pick deliberately.** `type-N`
+  is the recommended target, but it matches `text-mN` only at the `lg` breakpoint and
+  up; below that it is deliberately smaller (`1.15^N` at mobile, `1.2^N` at `md`,
+  against `text-mN`'s flat `1.25^N`), and it adds proportional letter spacing. So
+  `type-6` is 3.81em on desktop like `text-m6`, but 2.31em on mobile. Use `type-N` if
+  you want that responsive behavior — it is why the scale exists. Use the arbitrary
+  value if you need the current rendering preserved byte-for-byte at every breakpoint.
+  `type-0` and `text-m0` are identical (both a flat 1em).
 
 - **The Pro font fallbacks are inert for most projects.** `font-sans` and `font-serif`
   keep leading with Source Sans 3 and Source Serif 4; v8 only drops the superseded

--- a/docs/components/styles.md
+++ b/docs/components/styles.md
@@ -24,4 +24,4 @@ A set of composable typography utility classes used across the design system for
 
 ## Notes
 - These classes use the `decanter.typography` theme tokens so they will update when project-specific theme extensions are applied.
-- The `.basefont-XX` utilities are intended for quick base-size overrides for sections that need a slightly larger base font.
+- The `.basefont-19` – `.basefont-23` utilities are intended for quick base-size overrides for sections that need a slightly larger base font.

--- a/docs/index.md
+++ b/docs/index.md
@@ -169,7 +169,7 @@ This index lists all custom CSS classes provided by the Decanter design system (
 - **Max Width** — `.max-w-10` – `.max-w-1000`, `.max-w-prose-wide` (see Theme > Max Width)
 - **Transition Duration** — sets the duration implied by `.transition`, `.transition-colors` and the other `transition-*` utilities to 250ms (Tailwind's default is 150ms). This adds no class of its own; to set a duration explicitly use Tailwind's `.duration-*` scale or an arbitrary value like `.duration-[400ms]`. (see Theme > Transition Duration)
 - **Screens (Breakpoints)** — `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl` (see Theme > Screens)
-- **Font Family** — `font-mono` _(deprecated — Decanter's Roboto Mono stack is removed in v8; the class remains with Tailwind's default stack)_, `font-sans`, `font-serif`, `font-slab` _(deprecated — removed in v8)_, `font-stanford` (see Theme > Font Family)
+- **Font Family** — `font-mono` _(deprecated — Decanter's Roboto Mono stack is removed in v8; the class remains with Tailwind's default stack)_, `font-sans`, `font-serif` _(both keep Source Sans 3 / Source Serif 4; their deprecated Source Sans Pro / Source Serif Pro fallbacks are removed in v8)_, `font-slab` _(deprecated — removed in v8)_, `font-stanford` (see Theme > Font Family)
 
 ## Variants
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -162,12 +162,12 @@ This index lists all custom CSS classes provided by the Decanter design system (
 - **Border Width** — `.border-3`, `.border-5`, `.border-6`, `.border-7` (see Theme > Border Width)
 - **Border Radius** — `.rounded` default set to `0.3rem` (see Theme > Border Radius)
 - **Gap Scale** — `xs` (20px), `lg` (36px), `xl` (40px), `2xl` (48px) (see Theme > Gap)
-- **Font Size Scale** — `.text-11` – `.text-30`, `.text-m0` – `.text-m9`, `.text--m1`, `.text-09em` (see Theme > Font Size)
+- **Font Size Scale** — `.text-11` – `.text-30` (see Theme > Font Size), `.text-m0` – `.text-m9`, `.text-09em`, `.-text-m1` _(deprecated — use `.type-0` – `.type-9`, or an arbitrary value such as `text-[.9em]`; will be removed in v8)_
 - **Font Weight Scale** — `.font-regular` _(deprecated — use `.font-normal`; will be removed in v8)_ (see Theme > Font Weight)
 - **Line Clamp** — `.line-clamp-7` – `.line-clamp-12` (see Theme > Line Clamp)
 - **Line Height** — `.leading-tight`, `.leading-display`, `.leading-snug`, `.leading-cozy`, `.leading` (default), `.leading-half`, `.leading-trim` (see Theme > Line Height)
 - **Max Width** — `.max-w-10` – `.max-w-1000`, `.max-w-prose-wide` (see Theme > Max Width)
-- **Transition Duration** — `.duration` (default 250ms) (see Theme > Transition Duration)
+- **Transition Duration** — sets the duration implied by `.transition`, `.transition-colors` and the other `transition-*` utilities to 250ms (Tailwind's default is 150ms). This adds no class of its own; to set a duration explicitly use Tailwind's `.duration-*` scale or an arbitrary value like `.duration-[400ms]`. (see Theme > Transition Duration)
 - **Screens (Breakpoints)** — `sm`, `md`, `lg`, `xl`, `2xl`, `3xl`, `4xl` (see Theme > Screens)
 - **Font Family** — `font-mono` _(deprecated — Decanter's Roboto Mono stack is removed in v8; the class remains with Tailwind's default stack)_, `font-sans`, `font-serif`, `font-slab` _(deprecated — removed in v8)_, `font-stanford` (see Theme > Font Family)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -127,14 +127,14 @@ With Decanter imported, you have access to all Stanford brand colors:
 <code class="font-mono">Roboto Mono (Monospace)</code>
 <div class="font-stanford">Stanford Font (Logo)</div>
 
-<!-- Modular Typography Scale -->
-<h1 class="text-modular-5xl">Modular 5XL Heading</h1>
-<h2 class="text-modular-4xl">Modular 4XL Heading</h2>
-<p class="text-modular-base">Modular Base Text</p>
+<!-- Modular Typography Scale (.type-0 through .type-9) -->
+<h1 class="type-5">Step 5 Heading</h1>
+<h2 class="type-4">Step 4 Heading</h2>
+<p class="type-0">Base Text</p>
 
-<!-- Fluid Typography (Responsive) -->
-<h1 class="text-fluid-5xl">Fluid 5XL (Scales with viewport)</h1>
-<p class="text-fluid-base">Fluid Base Text</p>
+<!-- Fluid Typography (.fluid-type-0 through .fluid-type-10) -->
+<h1 class="fluid-type-5">Fluid step 5 (Scales with viewport)</h1>
+<p class="fluid-type-0">Fluid Base Text</p>
 ```
 
 ## Framework-Specific Examples

--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -13,7 +13,7 @@ Stanford's theme plugins extend Tailwind CSS with carefully crafted design token
 
 ### Typography System
 - **[fontFamily.md](./fontFamily.md)** - Stanford brand typography using Source Sans Pro with system font fallbacks
-- **[fontSize.md](./fontSize.md)** - Modular type scale from m1 (14px) to m8 (48px) with responsive line heights
+- **[fontSize.md](./fontSize.md)** - Pixel-based sizes `.text-11` – `.text-30`, plus the deprecated em-based sizes
 - **[fontWeight.md](./fontWeight.md)** - Typography weight scale from light (300) to black (900) with semantic naming
 - **[lineHeight.md](./lineHeight.md)** - Optimized line spacing system for readability and vertical rhythm
 

--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -12,7 +12,7 @@ Stanford's theme plugins extend Tailwind CSS with carefully crafted design token
 - **[colors.md](./colors.md)** - Stanford's official color palette including Cardinal Red, digital accent colors, grayscale system, and semantic color applications
 
 ### Typography System
-- **[fontFamily.md](./fontFamily.md)** - Stanford brand typography using Source Sans Pro with system font fallbacks
+- **[fontFamily.md](./fontFamily.md)** - Stanford brand typography using Source Sans 3 and Source Serif 4 with system font fallbacks
 - **[fontSize.md](./fontSize.md)** - Pixel-based sizes `.text-11` – `.text-30`, plus the deprecated em-based sizes
 - **[fontWeight.md](./fontWeight.md)** - Typography weight scale from light (300) to black (900) with semantic naming
 - **[lineHeight.md](./lineHeight.md)** - Optimized line spacing system for readability and vertical rhythm

--- a/docs/themes/borderWidth.md
+++ b/docs/themes/borderWidth.md
@@ -30,7 +30,7 @@ Extends Tailwind's default border widths (1px, 2px, 4px, 8px) with additional 3p
 </div>
 
 <!-- Emphasis elements -->
-<blockquote class="border-l-5 border-poppy pl-6 py-4 bg-illuminating-yellow/10">
+<blockquote class="border-l-5 border-poppy pl-6 py-4 bg-illuminating/10">
   <p class="italic">Important quote with 5px accent border</p>
 </blockquote>
 ```

--- a/docs/themes/fontFamily.md
+++ b/docs/themes/fontFamily.md
@@ -13,14 +13,27 @@
 >   Tailwind's default system monospace stack. Add `mono` to your own config if you
 >   need Roboto Mono specifically.
 
+> **Deprecated in v8: the Source Sans Pro and Source Serif Pro fallbacks.** `font-sans`
+> and `font-serif` keep their leading families — Source Sans 3 and Source Serif 4 — but
+> drop the superseded Pro entry behind each in v8:
+>
+> - `font-sans`: `Source Sans 3`, ~~`Source Sans Pro`~~, `Helvetica Neue`, …
+> - `font-serif`: `Source Serif 4`, ~~`Source Serif Pro`~~, `Georgia`, …
+>
+> **Most projects are unaffected.** Decanter's `fonts.css` and `fonts-basic.css` only
+> load Source Sans 3 and Source Serif 4, so the Pro entries never match unless you load
+> those families yourself. If you do — or you rely on them being installed locally —
+> make sure Source Sans 3 and Source Serif 4 are available before upgrading, or the
+> next fallback (Helvetica Neue / Georgia) will be used instead.
+
 ## Overview
 Provides Stanford's official typography stack with carefully curated font families including the Stanford ligature font used for the logo wordmark, Source Sans 3, Source Serif 4 with appropriate fallbacks.
 
 ## Generated CSS Classes
 
 - **Stanford ligature**: `.font-stanford` - Stanford ligature font for the logo with serif fallback
-- **Sans serif**: `.font-sans` - Source Sans 3 with sans serif fallback
-- **Serif**: `.font-serif` - Source Serif 4 with serif fallback
+- **Sans serif**: `.font-sans` - Source Sans 3 with sans serif fallback _(the Source Sans Pro fallback is deprecated — removed in v8)_
+- **Serif**: `.font-serif` - Source Serif 4 with serif fallback _(the Source Serif Pro fallback is deprecated — removed in v8)_
 - **Monospace**: `.font-mono` - Roboto Mono with monospace fallback _(deprecated — Decanter's stack is removed in v8; the class remains with Tailwind's default stack)_
 - **Slab**: `.font-slab` - Roboto Slab with serif fallback _(deprecated — removed in v8)_
 

--- a/docs/themes/fontSize.md
+++ b/docs/themes/fontSize.md
@@ -2,34 +2,24 @@
 
 **File**: `/src/plugins/theme/fontSize.js`
 
+> **Deprecated.** The em-based scale — `.text-m0` through `.text-m9`, `.text-09em`, `.-text-m1`
+> — will be removed in v8. Use the modular type classes `.type-0`
+> through `.type-9` instead: they are responsive and carry the proportional letter
+> spacing these plain font sizes lack. For a one-off size, use an arbitrary value
+> such as `text-[1.25em]`. The pixel-based `.text-11` – `.text-30` sizes are not
+> deprecated.
+
 ## Overview
 Provides a comprehensive font size system with pixel-based sizes, modular typography scales, and em-based sizes for use in different scenarios.
 
 ## Generated CSS Classes
 
 - **Pixel-based sizes**: `.text-11` through `.text-30` (11px to 30px in rem units)
-- **Modular scale**: `.text-m0` through `.text-m9` (1em to 7.45em using 1.25 ratio)
-- **Em-based sizes**: `.text-01em` through `.text-09em`
-
-## Usage
-
-```html
-<!-- Pixel-based font sizes -->
-<p class="text-16">Body text (16px)</p>
-<h3 class="text-24">Section heading (24px)</h3>
-<small class="text-12">Helper text (12px)</small>
-
-<!-- Modular typography scale -->
-<h1 class="text-m6">Large heading (3.81em)</h1>
-<h2 class="text-m4">Medium heading (2.44em)</h2>
-<p class="text-m0">Base text (1em)</p>
-<small class="text--m1">Small text (0.9em)</small>
-
-<!-- Responsive font sizes -->
-<h1 class="text-m4 md:text-m5 lg:text-m6">
-  Responsive heading
-</h1>
-```
+- **Modular scale**: `.text-m0` through `.text-m9` (1em to 7.45em using 1.25 ratio) _(deprecated — use `.type-0` – `.type-9`, or the square bracket notation, e.g. `text-[1.25em]`)_
+- **Em-based sizes**: `.text-09em` (0.9em) _(deprecated — use `text-[.9em]`)_
+  - The `-m1` theme key generates `.-text-m1`, not `.text--m1` — Tailwind reads the
+    leading `-` as a negative modifier. It is the same 0.9em as `.text-09em`.
+    _(deprecated — use `text-[.9em]`)_
 
 ## Customization
 
@@ -42,155 +32,42 @@ module.exports = {
         // Add custom sizes
         '32': '3.2rem',
         '36': '3.6rem',
-        // Add custom modular steps
-        'm10': '9.31em',
-        // Override existing sizes
-        'm6': '4em', // Custom large heading size
       },
     },
   },
 }
 ```
 
-### Modular Typography System
-
-#### Responsive Scale (m0 - m9)
-The modular typography system provides responsive font sizes that adapt to screen size and reading context:
-
-```javascript
-// Modular typography with responsive line heights
-'m0': ['0.8rem', { lineHeight: '1.3' }],    // 12.8px at base - smallest modular size
-'m1': ['0.9rem', { lineHeight: '1.4' }],    // 14.4px at base - small supporting text
-'m2': ['1rem', { lineHeight: '1.5' }],      // 16px at base - body text
-'m3': ['1.125rem', { lineHeight: '1.5' }],  // 18px at base - large body text
-'m4': ['1.3rem', { lineHeight: '1.4' }],    // 20.8px at base - small headings
-'m5': ['1.5rem', { lineHeight: '1.3' }],    // 24px at base - medium headings
-'m6': ['1.8rem', { lineHeight: '1.2' }],    // 28.8px at base - large headings
-'m7': ['2.2rem', { lineHeight: '1.2' }],    // 35.2px at base - display headings
-'m8': ['2.6rem', { lineHeight: '1.1' }],    // 41.6px at base - major headings
-'m9': ['3.2rem', { lineHeight: '1.1' }]     // 51.2px at base - hero text
-```
-
-**Responsive Behavior:**
-- **Mobile**: Base scale optimized for mobile reading
-- **Tablet**: Scales proportionally for larger screens
-- **Desktop**: Full scale for optimal desktop reading
-- **Print**: Optimized for print media with adjusted line heights
-
-**Usage Guidelines:**
-- **m0-m1**: Supporting text, captions, metadata
-- **m2-m3**: Body text, paragraphs, lists
-- **m4-m5**: Subheadings, section titles
-- **m6-m7**: Major headings, page titles
-- **m8-m9**: Hero text, display typography
-
 **Usage Examples:**
 ```html
 <!-- Academic article structure -->
 <article class="prose">
   <header>
-    <h1 class="text-m8 font-bold text-cardinal-red mb-4">
+    <h1 class="text-30 font-bold text-cardinal-red mb-4">
       Artificial Intelligence in Climate Research
     </h1>
-    <div class="text-m1 text-black-60 mb-8">
+    <div class="text-20 text-black-60 mb-8">
       <span>Published March 15, 2024</span> •
       <span>Dr. Sarah Chen, Environmental Science</span>
     </div>
   </header>
-
-  <div class="space-y-6">
-    <p class="text-m3 font-medium text-black leading-relaxed">
-      Stanford researchers have developed groundbreaking AI models that can predict climate patterns with unprecedented accuracy.
-    </p>
-
-    <h2 class="text-m6 font-semibold text-black mt-12 mb-4">
-      Research Methodology
-    </h2>
-
-    <p class="text-m2 leading-relaxed text-black-90">
-      The study utilized machine learning algorithms trained on decades of climate data from multiple sources...
-    </p>
-
-    <h3 class="text-m5 font-medium text-black mt-8 mb-3">
-      Data Collection Process
-    </h3>
-
-    <p class="text-m2 leading-relaxed text-black-90">
-      Our team collected atmospheric data from 150 monitoring stations worldwide...
-    </p>
-
-    <aside class="text-m1 text-black-50 border-l-4 border-cardinal-red-light pl-4">
-      For technical details, see the complete methodology in the supplementary materials.
-    </aside>
-  </div>
 </article>
-```
-
-### Convenience Classes
-
-#### type-* Classes (Semantic Aliases)
-The modular scale is also available through semantic `type-*` classes:
-
-```javascript
-// Semantic aliases for modular scale
-'type-0': ['0.8rem', { lineHeight: '1.3' }],   // Same as m0
-'type-1': ['0.9rem', { lineHeight: '1.4' }],   // Same as m1
-'type-2': ['1rem', { lineHeight: '1.5' }],     // Same as m2
-'type-3': ['1.125rem', { lineHeight: '1.5' }], // Same as m3
-'type-4': ['1.3rem', { lineHeight: '1.4' }],   // Same as m4
-'type-5': ['1.5rem', { lineHeight: '1.3' }],   // Same as m5
-'type-6': ['1.8rem', { lineHeight: '1.2' }],   // Same as m6
-'type-7': ['2.2rem', { lineHeight: '1.2' }],   // Same as m7
-'type-8': ['2.6rem', { lineHeight: '1.1' }],   // Same as m8
-'type-9': ['3.2rem', { lineHeight: '1.1' }]    // Same as m9
-```
-
-**Usage Examples:**
-```html
-<!-- Using type-* classes for semantic meaning -->
-<article>
-  <h1 class="type-8">Article Title</h1>         <!-- Hero heading -->
-  <h2 class="type-6">Section Heading</h2>       <!-- Major heading -->
-  <h3 class="type-5">Subsection</h3>            <!-- Minor heading -->
-  <p class="type-2">Body text content...</p>     <!-- Body text -->
-  <small class="type-0">Caption text</small>     <!-- Supporting text -->
-</article>
-
-<!-- Design system documentation -->
-<div class="space-y-4">
-  <div class="type-9 text-cardinal-red">Hero Display</div>
-  <div class="type-8 text-black">Page Title</div>
-  <div class="type-7 text-black">Section Title</div>
-  <div class="type-6 text-black">Large Heading</div>
-  <div class="type-5 text-black">Medium Heading</div>
-  <div class="type-4 text-black">Small Heading</div>
-  <div class="type-3 text-black">Large Body</div>
-  <div class="type-2 text-black">Regular Body</div>
-  <div class="type-1 text-black">Small Text</div>
-  <div class="type-0 text-black">Caption</div>
-</div>
 ```
 
 ## Line Height Integration
 
-### Optimized Line Heights by Size Range
+#### Small Text
+- **Line height**: 1.3 - 1.4 (comfortable for reading small text)
+- **Use cases**: Card text, captions, footnotes
 
-The font size system includes carefully calibrated line heights:
-
-#### Small Text (11px-16px)
-- **Line height**: 1.5 (comfortable for reading small text)
-- **Use cases**: Interface elements, form labels, navigation
-
-#### Body Text (17px-22px)
+#### Body Text
 - **Line height**: 1.4-1.5 (optimal for reading comfort)
 - **Use cases**: Paragraphs, articles, content blocks
 
-#### Large Text (23px-26px)
-- **Line height**: 1.3 (tighter for visual hierarchy)
-- **Use cases**: Subheadings, card titles
+#### Large Body Text
+- **Line height**: 1.4 - 1.5
+- **Use cases**: Subheadings, intros
 
-#### Headings (27px+)
+#### Headings
 - **Line height**: 1.1-1.2 (tight for visual impact)
 - **Use cases**: Page titles, hero text, display headings
-
-This comprehensive font size system provides the precision needed for interface design while offering the flexibility and reading optimization required for Stanford's diverse digital content needs.

--- a/docs/themes/fontSize.md
+++ b/docs/themes/fontSize.md
@@ -48,7 +48,7 @@ module.exports = {
 **Usage Examples:**
 ```html
 <!-- Academic article structure -->
-<article class="prose">
+<article>
   <header>
     <h1 class="text-30 font-bold text-cardinal-red mb-4">
       Artificial Intelligence in Climate Research

--- a/docs/themes/fontSize.md
+++ b/docs/themes/fontSize.md
@@ -2,24 +2,31 @@
 
 **File**: `/src/plugins/theme/fontSize.js`
 
-> **Deprecated.** The em-based scale — `.text-m0` through `.text-m9`, `.text-09em`, `.-text-m1`
-> — will be removed in v8. Use the modular type classes `.type-0`
+> **Deprecated.** The em-based sizes — `.text-m0` through `.text-m9`, `.text-09em` and
+> `.-text-m1` — will be removed in v8. Use the modular typography classes `.type-0`
 > through `.type-9` instead: they are responsive and carry the proportional letter
 > spacing these plain font sizes lack. For a one-off size, use an arbitrary value
 > such as `text-[1.25em]`. The pixel-based `.text-11` – `.text-30` sizes are not
 > deprecated.
 
 ## Overview
-Provides a comprehensive font size system with pixel-based sizes, modular typography scales, and em-based sizes for use in different scenarios.
+Provides a comprehensive font size system with pixel-based sizes and em-based sizes for
+use in different scenarios.
+
+Not to be confused with [Modular Typography](../components/modular-typography.md), which
+is the `.type-0` – `.type-9` component scale. The em-based sizes below are plain
+`font-size` utilities with no responsive steps or letter spacing.
 
 ## Generated CSS Classes
 
 - **Pixel-based sizes**: `.text-11` through `.text-30` (11px to 30px in rem units)
-- **Modular scale**: `.text-m0` through `.text-m9` (1em to 7.45em using 1.25 ratio) _(deprecated — use `.type-0` – `.type-9`, or the square bracket notation, e.g. `text-[1.25em]`)_
-- **Em-based sizes**: `.text-09em` (0.9em) _(deprecated — use `text-[.9em]`)_
-  - The `-m1` theme key generates `.-text-m1`, not `.text--m1` — Tailwind reads the
-    leading `-` as a negative modifier. It is the same 0.9em as `.text-09em`.
-    _(deprecated — use `text-[.9em]`)_
+- **Em-based sizes** _(all deprecated — see above)_
+  - `.text-m0` through `.text-m9` — 1em to 7.45em, each step 1.25× the previous
+    _(use `.type-0` – `.type-9`, or the square bracket notation, e.g. `text-[1.25em]`)_
+  - `.text-09em` — 0.9em _(use `text-[.9em]`)_
+  - `.-text-m1` — the same 0.9em. Note the `-m1` theme key generates `.-text-m1`, not
+    `.text--m1`: Tailwind reads the leading `-` as a negative modifier.
+    _(use `text-[.9em]`)_
 
 ## Customization
 

--- a/docs/themes/fontWeight.md
+++ b/docs/themes/fontWeight.md
@@ -91,12 +91,12 @@ font-regular     /* 400 - Same as font-normal */
 ### Legacy Compatibility
 ```html
 <!-- Decanter v6 style (still supported) -->
-<p class="font-regular text-m2">
+<p class="font-regular">
   Body text using legacy font-regular class
 </p>
 
 <!-- Modern Tailwind style (recommended) -->
-<p class="font-normal text-m2">
+<p class="font-normal">
   Body text using standard font-normal class
 </p>
 ```
@@ -104,33 +104,33 @@ font-regular     /* 400 - Same as font-normal */
 ### Stanford Typography Hierarchy
 ```html
 <!-- Complete weight hierarchy using both systems -->
-<article class="font-source-sans-3">
+<article>
   <!-- Hero heading -->
-  <h1 class="text-m8 font-bold text-cardinal-red">
+  <h1 class="type-6 font-bold">
     Major Heading - Bold (700)
   </h1>
-  
+
   <!-- Section headings -->
-  <h2 class="text-m6 font-semibold text-black mt-[2em] mb-[0.75em]">
+  <h2 class="type-4 font-semibold">
     Section Heading - Semibold (600)
   </h2>
-  
+
   <!-- Subheadings -->
-  <h3 class="text-m5 font-medium text-black mt-[1.5em] mb-[0.5em]">
+  <h3 class="type-3 font-medium">
     Subheading - Medium (500)
   </h3>
-  
+
   <!-- Body text with both options -->
-  <p class="text-m2 font-regular leading-relaxed mb-[1.5em]">
+  <p class="type-0 font-regular leading-normal">
     Body text using legacy font-regular class (400 weight)
   </p>
-  
-  <p class="text-m2 font-normal leading-relaxed mb-[1.5em]">
+
+  <p class="type-0 font-normal leading-normal">
     Body text using standard font-normal class (400 weight)
   </p>
-  
+
   <!-- Light emphasis -->
-  <p class="text-m2 font-light text-black-70">
+  <p class="type-0 font-light text-black-70">
     Supporting text with light weight (300)
   </p>
 </article>

--- a/docs/themes/gap.md
+++ b/docs/themes/gap.md
@@ -125,8 +125,8 @@ This utility automatically applies:
 ```html
 <!-- Navigation with adaptive spacing -->
 <nav class="flex flex-wrap gap-xs lg:gap-lg items-center">
-  <div class="font-stanford text-m4 text-cardinal-red">Stanford</div>
-  <ul class="flex gap-xs lg:gap-lg text-m2">
+  <div class="font-stanford type-4 text-cardinal-red">Stanford</div>
+  <ul class="flex gap-xs lg:gap-lg type-2">
     <li><a href="#" class="hover:text-cardinal-red">Academics</a></li>
     <li><a href="#" class="hover:text-cardinal-red">Research</a></li>
     <li><a href="#" class="hover:text-cardinal-red">Campus Life</a></li>

--- a/docs/themes/lineHeight.md
+++ b/docs/themes/lineHeight.md
@@ -7,7 +7,7 @@ Provides Stanford-optimized line height values that override Tailwind defaults w
 
 ## Generated CSS Classes
 
-- **Button text**: `.leading-tight` (1.1 - overrides Tailwind's 1.25)
+- **Button label/headings**: `.leading-tight` (1.1 - overrides Tailwind's 1.25)
 - **Display/headings**: `.leading-display` (1.2)
 - **Card text**: `.leading-snug` (1.3 - overrides Tailwind's 1.375)
 - **Small paragraphs**: `.leading-cozy` (1.4)
@@ -24,12 +24,12 @@ Provides Stanford-optimized line height values that override Tailwind defaults w
 </button>
 
 <!-- Headings and display text -->
-<h1 class="leading-display text-4xl font-bold">
+<h1 class="leading-display fluid-type-6 font-bold">
   Display Line Height
 </h1>
 
 <!-- Card content -->
-<div class="leading-snug p-4 bg-white rounded">
+<div class="leading-snug rs-p-2 bg-white rounded">
   <p>Card content with snug line height for compact layouts</p>
 </div>
 
@@ -41,12 +41,11 @@ Provides Stanford-optimized line height values that override Tailwind defaults w
 <!-- Logo lockups -->
 <div class="leading-half">
   <div>Stanford</div>
-  <div>University</div>
 </div>
 
-<!-- Source Sans Pro trimmed -->
+<!-- Source Sans 3 trimmed -->
 <p class="font-sans leading-trim">
-  Trimmed leading for Source Sans Pro typography
+  Trimmed leading for Source Sans 3 typography
 </p>
 ```
 

--- a/docs/themes/transitionDuration.md
+++ b/docs/themes/transitionDuration.md
@@ -8,7 +8,14 @@ Overrides Tailwind's default transition duration from 150ms to a smoother 250ms 
 
 ## Generated CSS Classes
 
-- `.duration` — 250ms (Stanford default)
+This sets Tailwind's `DEFAULT` transition duration, which generates **no class of its
+own** — Tailwind's `transitionDuration` plugin is registered with `filterDefault`, so
+there is no `.duration` utility. What the 250ms does is change the duration *implied*
+by the `transition-*` utilities, which emit `transition-duration: 250ms` instead of
+Tailwind's stock 150ms:
+
+- `.transition`, `.transition-all`, `.transition-colors`, `.transition-opacity`,
+  `.transition-shadow`, `.transition-transform` — all imply 250ms
 - Default Tailwind durations (preserved):
   - `.duration-0` — 0ms
   - `.duration-75` — 75ms
@@ -22,14 +29,20 @@ Overrides Tailwind's default transition duration from 150ms to a smoother 250ms 
 
 ## Usage
 
-Apply the class to enable transitions with the default 250ms duration:
+Add a `transition-*` utility and you get the 250ms default with no duration class:
 ```html
-<button class="transition duration hover:bg-cardinal-red">Action</button>
+<button class="transition hover:bg-cardinal-red">Action</button>
 ```
 
-Combine with other duration utilities:
+Add a `duration-*` utility to override it:
 ```html
 <div class="transition duration-500 hover:scale-105">Animated</div>
+```
+
+250ms is not on Tailwind's duration scale, so to state it explicitly use an arbitrary
+value:
+```html
+<div class="transition duration-[250ms] hover:scale-105">Animated</div>
 ```
 
 ## Customization

--- a/docs/utilities/backface-visibility.md
+++ b/docs/utilities/backface-visibility.md
@@ -10,7 +10,7 @@ Provides the `.backface-hidden` class to hide the back face of elements during 3
 
 ## Usage
 ```html
-<div class="transform-style-preserve-3d backface-hidden">
+<div class="[transform-style:preserve-3d] backface-hidden">
   <!-- 3D element content -->
 </div>
 ```

--- a/src/plugins/theme/fontFamily.js
+++ b/src/plugins/theme/fontFamily.js
@@ -10,6 +10,10 @@ module.exports = function () {
     mono: ['"Roboto Mono"', 'Menlo', '"Courier New"', 'monospace'],
     sans: [
       '"Source Sans 3"',
+      // @deprecated The Source Sans Pro fallback is removed in v8. Decanter's
+      // fonts.css/fonts-basic.css only load Source Sans 3, so this entry only takes
+      // effect for projects loading Source Sans Pro themselves. Make sure Source
+      // Sans 3 is loaded; the next fallback becomes Helvetica Neue.
       '"Source Sans Pro"',
       '"Helvetica Neue"',
       'Helvetica',
@@ -18,6 +22,8 @@ module.exports = function () {
     ],
     serif: [
       '"Source Serif 4"',
+      // @deprecated The Source Serif Pro fallback is removed in v8. See the note on
+      // `sans` above; the next fallback becomes Georgia.
       '"Source Serif Pro"',
       'Georgia',
       'Times',

--- a/src/plugins/theme/fontSize.js
+++ b/src/plugins/theme/fontSize.js
@@ -1,6 +1,6 @@
 /**
  * Font Size Defaults.
- * Also see our custom modular typography classes (.type-0 to .type-6).
+ * Also see our custom modular typography classes (.type-0 to .type-9).
  */
 module.exports = function () {
   return {
@@ -27,19 +27,17 @@ module.exports = function () {
     29: '2.9rem',
     30: '3rem',
     /**
-     * Font sizes classes for use in modular typography utilities.
-     * To take full advantage of modular typography which inlude letter spacing adjustments propotional to font sizes,
-     * use type-0 to type-9 instead
+     * Em-based font sizes, each step 1.25x the previous. These are plain font sizes:
+     * they are NOT the modular typography system, which is `type-0` to `type-9` and
+     * additionally carries responsive steps and proportional letter spacing.
      * See src/plugins/theme/decanter.js
      *
-     * @deprecated The em-based `m*` scale below is removed in v8. Use the modular
-     * type classes `type-0` to `type-9`, which are responsive and include the
-     * proportional letter spacing these plain font sizes lack. For a one-off
-     * size, use an arbitrary value such as `text-[1.25em]`.
+     * @deprecated Removed in v8. Use the modular typography classes `type-0` to
+     * `type-9`, or for a one-off size an arbitrary value such as `text-[1.25em]`.
      */
-    m0: '1em', // text-m0 equals to 1em (modular step 0 = base)
-    m1: '1.25em', // text-m1 = 1.25 x 1em (modular step 1)
-    m2: '1.56em', // text-m2 = 1.25 x 1.25 x 1em (modular step 2) and so on
+    m0: '1em', // text-m0 equals to 1em (base)
+    m1: '1.25em', // text-m1 = 1.25 x 1em
+    m2: '1.56em', // text-m2 = 1.25 x 1.25 x 1em, and so on
     m3: '1.95em',
     m4: '2.44em',
     m5: '3.05em',

--- a/src/plugins/theme/fontSize.js
+++ b/src/plugins/theme/fontSize.js
@@ -31,6 +31,11 @@ module.exports = function () {
      * To take full advantage of modular typography which inlude letter spacing adjustments propotional to font sizes,
      * use type-0 to type-9 instead
      * See src/plugins/theme/decanter.js
+     *
+     * @deprecated The em-based `m*` scale below is removed in v8. Use the modular
+     * type classes `type-0` to `type-9`, which are responsive and include the
+     * proportional letter spacing these plain font sizes lack. For a one-off
+     * size, use an arbitrary value such as `text-[1.25em]`.
      */
     m0: '1em', // text-m0 equals to 1em (modular step 0 = base)
     m1: '1.25em', // text-m1 = 1.25 x 1em (modular step 1)
@@ -42,9 +47,13 @@ module.exports = function () {
     m7: '4.77em',
     m8: '5.96em',
     m9: '7.45em',
-    // text--m1 doesn't use the 1.25 scale factor.
-    // Merely a convenience class for a slightly smaller font size than the base step
+    // -m1 Doesn't use the 1.25 scale factor. Merely a convenience value for a slightly
+    // smaller font size than the base step.
+    // NOTE: this key does not produce `text--m1`. Tailwind reads the leading `-` as a
+    // negative modifier and emits `.-text-m1`.
+    // @deprecated Removed in v8.
     '-m1': '0.9em',
-    '09em': '0.9em', // alias for text--m1
+    // Working alias for the `-m1` above. @deprecated Removed in v8.
+    '09em': '0.9em',
   };
 };

--- a/src/plugins/theme/lineHeight.js
+++ b/src/plugins/theme/lineHeight.js
@@ -9,6 +9,6 @@ module.exports = function () {
     cozy: '1.4', // Normal for slightly smaller paragraph font sizes (eg, 19px)
     DEFAULT: '1.5', // Normal for regular paragraphs
     half: '0.5', // Useful for logo lockup
-    trim: '0.75', // Trim leading for Source Sans Pro
+    trim: '0.75', // Trim leading for Source Sans 3
   };
 };


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Flags `text-m0`–`text-m9`, `-text-m1` and `text-09em` as deprecated, and fixes several
documented classes that never existed.
- Deprecate Source Sans Pro and Source Serif Pro in the `font-sans` and `font-serif` font stack

### Doc corrections

Four classes were documented but are never generated. All predate this branch:

| Documented | Reality |
| --- | --- |
| `.duration` — 250ms | Doesn't exist. Tailwind registers `transitionDuration` with `filterDefault: true`, which suppresses the `DEFAULT` class. The 250ms is instead the duration *implied* by `.transition`, `.transition-all`, `.transition-colors`, `.transition-opacity`, `.transition-shadow` and `.transition-transform`. |
| `.text--m1` — 0.9em | Doesn't exist. Tailwind reads the leading `-` in the `-m1` key as a negative modifier and emits `.-text-m1`, so `.text--m1` in markup matches nothing. This is why the `09em` alias was added. |
| `.text-01em` – `.text-09em` | Only `09em` is a font size; `01em`–`09em` are **spacing** tokens. |
| `font-source-sans-3` | Not a font-family key (`sans`, `serif`, `slab`, `stanford`, `mono`). |

Also swapped deprecated classes out of unrelated examples in `docs/themes/gap.md`
(`text-m4`/`text-m2` → `type-4`/`type-2`) and `docs/themes/fontWeight.md`, and dropped
the Customization snippet in `fontSize.md` that demonstrated extending the now-deprecated
`m*` scale.

- Remove usage of non-existent Decanter classes from documentation


# Needed By (Date)
- Soon

# Urgency
- 5

# Steps to Test

1. Look at code

