### PR TITLE
Deprecate aspect-ratio plugin and the children: custom variants

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -83,8 +83,10 @@ Migrating now makes the v8 upgrade a no-op.
 | `text-m8` | `type-8`, or `text-[5.96em]` | Yes |
 | `text-m9` | `type-9`, or `text-[7.45em]` | Yes |
 | `text-09em`, `-text-m1` | `text-[.9em]` (no `type-*` equivalent — the 0.9em step is not on the scale) | Yes |
+| `aspect-w-*` / `aspect-h-*` (e.g. `aspect-w-16 aspect-h-9`), `aspect-none` | `aspect-[16/9]` on the wrapper, `size-full` on the child | Yes |
+| `children:`, `children-hover:`, `children-focus:`, `children-focus-visible:` | `*:`, `hover:*:`, `focus:*:`, `focus-visible:*:` — mind the order, see the note below | Yes |
 
-Four notes on the replacements:
+Five notes on the replacements:
 
 - **The two font size replacements are not equivalent — pick deliberately.** `type-N`
   is the recommended target, but it matches `text-mN` only at the `lg` breakpoint and
@@ -107,8 +109,22 @@ Four notes on the replacements:
   recommended. The replacement above reproduces the v7 styling if you need it, but
   prefer non-italic body-size text where you can.
 - **Use `aspect-[16/9]`, not `aspect-video`.** Decanter v7 loads
-  `@tailwindcss/aspect-ratio`, which suppresses Tailwind's core `aspect-*` utilities,
-  so `aspect-video` generates no CSS in v7. `aspect-[16/9]` works in both v7 and v8.
+  `@tailwindcss/aspect-ratio`, which replaces Tailwind's `theme.aspectRatio`, so
+  `aspect-auto`, `aspect-square` and `aspect-video` generate no CSS in v7. Arbitrary
+  values such as `aspect-[16/9]` work in both v7 and v8. v8 drops the plugin: the named
+  core utilities start working, and `aspect-w-*` / `aspect-h-*` / `aspect-none` stop
+  generating anything. Also note `aspect-w-*` absolutely positioned direct children to
+  fill the box — the `aspect-ratio` property does not, so add `size-full` to the child.
+  The brackets become optional in v8, which accepts bare fractions — `aspect-[3/2]` can
+  be shortened to `aspect-3/2` then — but the bracketed form keeps working, so migrate
+  now and drop the brackets later if you want.
+
+- **The `children:` replacements reverse the variant order.** `hover:*:underline`
+  compiles to `& > *:hover`, which is what `children-hover:` did. `*:hover:underline`
+  compiles to `&:hover > *` — every child of a hovered *parent*, a different thing. The
+  intuitive-looking form is the wrong one. Plain `children:` → `*:` is exact, and
+  prefixes and stacking carry over unchanged (`sm:children:` → `sm:*:`,
+  `last:children:` → `last:*:`).
 
 Upgrade from version 7.0.0-beta.1 to 7.0.0
 ------------------------------------------

--- a/docs/components/embed-container.md
+++ b/docs/components/embed-container.md
@@ -15,7 +15,8 @@
 > Use `aspect-[16/9]`, not `aspect-video`. Decanter v7 loads
 > `@tailwindcss/aspect-ratio`, which suppresses Tailwind's core `aspect-*` utilities,
 > so `aspect-video` generates no CSS here. `aspect-[16/9]` works today and continues
-> to work in v8 once that plugin is dropped.
+> to work in v8 once that plugin is dropped. v8 also accepts bare fractions, so
+> `aspect-[16/9]` can be written `aspect-16/9` there — no need to change anything now.
 
 ## Overview
 

--- a/docs/custom-variants.md
+++ b/docs/custom-variants.md
@@ -24,6 +24,24 @@ Usage example:
 ```
 
 ## Children Variants
+
+> **Deprecated.** These are removed in v8. Tailwind added the `*:` variant in v3.4.0,
+> which generates the same selectors:
+>
+> | Deprecated | Use instead | Selector |
+> | --- | --- | --- |
+> | `children:` | `*:` | `& > *` |
+> | `children-hover:` | `hover:*:` | `& > *:hover` |
+> | `children-focus:` | `focus:*:` | `& > *:focus` |
+> | `children-focus-visible:` | `focus-visible:*:` | `& > *:focus-visible` |
+>
+> Prefixes and stacking carry over unchanged — `sm:children:` becomes `sm:*:`,
+> `last:children:` becomes `last:*:`.
+>
+> **Put the state variant first.** `hover:*:` is `& > *:hover` (what `children-hover:`
+> did); `*:hover:` is `&:hover > *` — every child of a hovered *parent*, which is a
+> different thing.
+
 - **children**: Targets all direct children (`& > *`).
 - **children-hover**: Targets direct children on hover (`& > *:hover`).
 - **children-focus**: Direct children when focused (`& > *:focus`).
@@ -31,7 +49,14 @@ Usage example:
 
 Usage example:
 ```html
+<!-- Deprecated -->
 <div class="children-hover:text-cardinal-red">
+  <button>Child 1</button>
+  <button>Child 2</button>
+</div>
+
+<!-- Use instead -->
+<div class="hover:*:text-cardinal-red">
   <button>Child 1</button>
   <button>Child 2</button>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ This index lists all custom CSS classes provided by the Decanter design system (
 - `.centered-container`, `.cc` — Constrains content to centered max-width container. (see Components > Centered Container)
 - `.grid-gap` — Adds responsive gap between grid items. (see Components > Grid Gap)
 - `.embed-container` — Maintains responsive aspect ratio for embedded media. _(deprecated — use `aspect-[16/9]` with `size-full` on the embed; will be removed in v8)_ (see Components > Embed Container)
+- `.aspect-w-{1–16}`, `.aspect-h-{1–16}`, `.aspect-none` — Aspect-ratio boxes from `@tailwindcss/aspect-ratio`, using the `padding-bottom` hack with absolutely positioned children. _(deprecated — the dependency is dropped in v8; use `aspect-[16/9]` with `size-full` on the child)_
 - `.rs-*` — Responsive spacing utilities (`rs-m-`, `rs-p-` variants). (see Components > Responsive Spacing)
   - `.rs-m-{scale}`: responsive margin (all sides)
   - `.rs-p-{scale}`: responsive padding (all sides)
@@ -177,7 +178,7 @@ Custom variants added by Decanter for enhanced styling:
 - `hocus:` — Applies on hover and focus.
 - `hocus-visible:` — Applies on hover and `focus-visible`.
 - `group-hocus:` / `group-hocus-visible:` / `group-hocus-within:` — Applies when parent `.group` is hovered/focused.
-- `children:` / `children-hover:` / `children-focus:` / `children-focus-visible:` — Targets direct children in given states.
+- `children:` / `children-hover:` / `children-focus:` / `children-focus-visible:` — Targets direct children in given states. _(deprecated — use Tailwind's `*:` variant: `*:`, `hover:*:`, `focus:*:`, `focus-visible:*:`; will be removed in v8)_ (see Custom Variants)
 
 ## Removed Classes
 

--- a/static/index.html
+++ b/static/index.html
@@ -1330,29 +1330,29 @@ p q r s t u v w x y z { | } ~
               width decorator class, you'll need to add a parent container that wraps around your aspect ratio
               container. Below are a few commonly used ones.</p>
             <div class="w-full md:w-1/3 rs-mb-2">
-              <div class="aspect-w-1 aspect-h-1 bg-illuminating-dark text-black">
-                <div class="rs-p-4 grid justify-center content-center">
+              <div class="aspect-[1/1] bg-illuminating-dark text-black">
+                <div class="size-full rs-p-4 grid justify-center content-center">
                   <h3 class="mb-0">Square</h3>
                 </div>
               </div>
             </div>
             <div class="w-full md:w-1/3 rs-mb-2">
-              <div class="aspect-w-4 aspect-h-3 bg-plum-light text-white">
-                <div class="rs-p-4 grid justify-center content-center">
+              <div class="aspect-[4/3] bg-plum-light text-white">
+                <div class="size-full rs-p-4 grid justify-center content-center">
                   <h3 class="mb-0">4 x 3 Box</h3>
                 </div>
               </div>
             </div>
             <div class="w-full md:w-1/2 rs-mb-2">
-              <div class="aspect-w-16 aspect-h-9 bg-bay-dark text-white">
-                <div class="rs-p-4 grid justify-center content-center">
+              <div class="aspect-[16/9] bg-bay-dark text-white">
+                <div class="size-full rs-p-4 grid justify-center content-center">
                   <h3 class="mb-0">16 x 9 Box</h3>
                 </div>
               </div>
             </div>
             <div class="w-full md:w-1/2 rs-mb-2">
-              <div class="aspect-w-2 aspect-h-1 bg-poppy-dark text-white">
-                <div class="rs-p-4 grid justify-center content-center">
+              <div class="aspect-[2/1] bg-poppy-dark text-white">
+                <div class="size-full rs-p-4 grid justify-center content-center">
                   <h3 class="mb-0">2 x 1 Box</h3>
                 </div>
               </div>

--- a/tw.config.js
+++ b/tw.config.js
@@ -112,7 +112,12 @@ function createDecanterConfig(plugin, requireFn) {
         /**
          * Note: in TW v3.4.0, the *: variant is added for targeting direct children
          * https://github.com/tailwindlabs/tailwindcss/pull/12551
-         * Leaving these in for now for backwards compatibility.
+         *
+         * @deprecated Removed in v8. Use Tailwind's `*:` variant, which generates the
+         * same selectors: `children:` -> `*:`, `children-hover:` -> `hover:*:`,
+         * `children-focus:` -> `focus:*:`, `children-focus-visible:` ->
+         * `focus-visible:*:`. The state variant goes first: `hover:*:` is `& > *:hover`,
+         * while `*:hover:` is `&:hover > *` (all children of a hovered parent).
          */
         addVariant('children', '& > *');
         addVariant('children-hover', '& > *:hover');
@@ -121,6 +126,13 @@ function createDecanterConfig(plugin, requireFn) {
       }),
 
       // 3rd Party Plugins;
+      // @deprecated This dependency is dropped in v8, removing `aspect-w-1` through
+      // `aspect-w-16`, `aspect-h-1` through `aspect-h-16`, and `aspect-none`. Use
+      // `aspect-[16/9]` on the wrapper with `size-full` on the child (the padding-bottom
+      // hack positioned children absolutely). The plugin replaces Tailwind's
+      // `theme.aspectRatio`, so `aspect-auto`, `aspect-square` and `aspect-video`
+      // generate nothing in v7 and start working again in v8; arbitrary values such as
+      // `aspect-[16/9]` work in both.
       requireFn('@tailwindcss/aspect-ratio'),
       requireFn('@tailwindcss/forms'),
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Deprecate aspect-ratio plugin and the children: custom variants

# Needed By (Date)
- Soon

# Urgency
- 5

# Steps to Test

1. Take a look at what's changed
